### PR TITLE
#559B Fix list builder size container

### DIFF
--- a/semantic/src/site/collections/table.overrides
+++ b/semantic/src/site/collections/table.overrides
@@ -87,3 +87,11 @@
     border-bottom-right-radius: 10px;
   }
 }
+
+// For listBuilder table not overlap the Application/Review
+// Page area - will show scroll when bigger than container
+.ui.table.list-builder {
+  overflow: auto;
+  display: inline-block;
+  max-width: inherit;
+}

--- a/src/formElementPlugins/listBuilder/src/displayComponents/ListTableLayout.tsx
+++ b/src/formElementPlugins/listBuilder/src/displayComponents/ListTableLayout.tsx
@@ -11,7 +11,7 @@ const ListTableLayout: React.FC<ListLayoutProps> = ({
   isEditable = true,
 }) => {
   return (
-    <Table celled selectable={isEditable}>
+    <Table className="list-builder" celled selectable={isEditable}>
       <Table.Header>
         <Table.Row>
           {fieldTitles.map((title) => (


### PR DESCRIPTION
Partial for back-end issue https://github.com/openmsupply/application-manager-server/issues/559

### Changes
- Only fixed for table view (there is also Card and list views... probably good to check)
- Will just auto display a scrollbar when the table is larger than its container
<img width="942" alt="Screen Shot 2021-09-23 at 5 32 16 PM" src="https://user-images.githubusercontent.com/16461988/134459102-228a7ae9-c592-4f24-a5bf-77f0cb5b1e0d.png">


