### PR TITLE
Small change on the upload file plugin

### DIFF
--- a/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
+++ b/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
@@ -153,7 +153,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
           <Markdown text={label} semanticComponent="noParagraph" />
         </label>
       )}
-      <Markdown text={description} />
       <Segment.Group>
         {/* Dummy input button required, as Semantic Button can't
         handle file input. Link between this input and Semantic
@@ -249,6 +248,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
           })}
         </List>
       </Segment.Group>
+      <Markdown text={description} semanticComponent="noParagraph"/>
     </>
   )
   async function uploadFile(file: any) {


### PR DESCRIPTION
No issue related...

Done as a minor change to improve what has been requested (internally) on #1204 

Since we are using 2 fields for one type of question in the latest template being build (no naming since this is public), basically the changes are to instead of showing both like this:
![Screen Shot 2022-06-03 at 10 14 44 AM](https://user-images.githubusercontent.com/16461988/171748438-f95591ab-7bf0-4ca1-8241-41bb65783cb8.png)


Moving the description to the bottom. So it displays like this:
![Screen Shot 2022-06-03 at 10 00 07 AM](https://user-images.githubusercontent.com/16461988/171748448-0d03ff8c-f598-46a5-b87e-7679cf1dc0e3.png)

