### PR TITLE
File upload enhancements

### DIFF
--- a/semantic/src/site/elements/input.variables
+++ b/semantic/src/site/elements/input.variables
@@ -1,5 +1,3 @@
 /*******************************
     User Variable Overrides
 *******************************/
-
-@inputPlaceholderColor: @darkGrey;

--- a/src/formElementPlugins/fileUpload/config.json
+++ b/src/formElementPlugins/fileUpload/config.json
@@ -1,4 +1,4 @@
 {
-  "applicationViewThumbnailHeight": "80px",
+  "applicationViewThumbnailHeight": "60px",
   "summaryViewThumbnailHeight": "60px"
 }

--- a/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
+++ b/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
@@ -1,14 +1,11 @@
 import React, { useEffect, useState, useRef } from 'react'
-import { Button, Icon, Grid, List, Image, Message, Segment, Loader, Input } from 'semantic-ui-react'
+import { Button, Icon, List, Segment } from 'semantic-ui-react'
 import { nanoid } from 'nanoid'
 import { ApplicationViewProps } from '../../types'
 import { useLanguageProvider } from '../../../contexts/Localisation'
 import { useUserState } from '../../../contexts/UserState'
 import { postRequest } from '../../../utils/helpers/fetchMethods'
-import prefs from '../config.json'
-import './styles.css'
-import { FileDisplay } from './components/FileDisplay'
-import { FileDisplayWithDescription } from './components/FileDisplayWIthDescription'
+import { FileDisplay, FileDisplayWithDescription } from './components'
 
 export interface FileResponseData {
   uniqueId: string

--- a/src/formElementPlugins/fileUpload/src/SummaryView.tsx
+++ b/src/formElementPlugins/fileUpload/src/SummaryView.tsx
@@ -35,6 +35,11 @@ const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, respons
                     </a>
                   </p>
                 </Grid.Row>
+                {file?.description && (
+                  <Grid.Row centered style={{ boxShadow: 'none' }}>
+                    <p className="tiny-bit-smaller-text">{file.description}</p>
+                  </Grid.Row>
+                )}
               </Grid>
             </List.Item>
           ))}

--- a/src/formElementPlugins/fileUpload/src/components/FileDisplay.tsx
+++ b/src/formElementPlugins/fileUpload/src/components/FileDisplay.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { Icon, Grid, List, Image, Message, Loader } from 'semantic-ui-react'
+import { FileInfo } from '../ApplicationView'
+import prefs from '../../config.json'
+
+export interface FileDisplayProps {
+  file: FileInfo
+  onDelete: (key: string) => void
+  downloadUrl: string
+}
+
+export const FileDisplay = ({ file, onDelete, downloadUrl }: FileDisplayProps) => {
+  const { key, loading, error, errorMessage, filename, fileData } = file
+  return (
+    <List.Item style={{ position: 'relative', maxWidth: 150 }}>
+      <Grid verticalAlign="top" celled style={{ boxShadow: 'none' }}>
+        {error && (
+          <>
+            <Grid.Row
+              centered
+              style={{ boxShadow: 'none', height: 120, padding: 10 }}
+              verticalAlign="middle"
+            >
+              <Message negative compact>
+                <p>{errorMessage}</p>
+              </Message>
+            </Grid.Row>
+            <Grid.Row centered style={{ boxShadow: 'none' }}>
+              <p style={{ wordBreak: 'break-word' }}>{filename}</p>
+            </Grid.Row>
+          </>
+        )}
+        {loading && (
+          <>
+            <Grid.Row centered style={{ boxShadow: 'none', height: 120 }} verticalAlign="middle">
+              <Loader active size="medium">
+                Uploading
+              </Loader>
+            </Grid.Row>
+            <Grid.Row centered style={{ boxShadow: 'none' }}>
+              <p style={{ wordBreak: 'break-word' }}>{filename}</p>
+            </Grid.Row>
+          </>
+        )}
+        {fileData && (
+          <>
+            <Grid.Row centered style={{ boxShadow: 'none' }} verticalAlign="top">
+              <a href={downloadUrl + fileData.fileUrl} target="_blank">
+                <Image
+                  src={downloadUrl + fileData.thumbnailUrl}
+                  style={{ maxHeight: prefs.applicationViewThumbnailHeight }}
+                />
+              </a>
+            </Grid.Row>
+            <Grid.Row centered style={{ boxShadow: 'none' }}>
+              <p style={{ wordBreak: 'break-word' }}>
+                <a href={downloadUrl + fileData.fileUrl} target="_blank">
+                  {filename}
+                </a>
+              </p>
+            </Grid.Row>
+          </>
+        )}
+      </Grid>
+      <Icon
+        link
+        name="delete"
+        circular
+        fitted
+        color="grey"
+        onClick={() => onDelete(key)}
+        style={{ position: 'absolute', right: 0, top: 0 }}
+      />
+    </List.Item>
+  )
+}

--- a/src/formElementPlugins/fileUpload/src/components/FileDisplay.tsx
+++ b/src/formElementPlugins/fileUpload/src/components/FileDisplay.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Icon, Grid, List, Image, Message, Loader } from 'semantic-ui-react'
 import { FileInfo } from '../ApplicationView'
 import prefs from '../../config.json'
+import './styles.css'
 
 export interface FileDisplayProps {
   file: FileInfo
@@ -12,7 +13,7 @@ export interface FileDisplayProps {
 export const FileDisplay = ({ file, onDelete, downloadUrl }: FileDisplayProps) => {
   const { key, loading, error, errorMessage, filename, fileData } = file
   return (
-    <List.Item style={{ position: 'relative', maxWidth: 150 }}>
+    <List.Item className="file-item" style={{ position: 'relative', maxWidth: 150 }}>
       <Grid verticalAlign="top" celled style={{ boxShadow: 'none' }}>
         {error && (
           <>
@@ -69,6 +70,7 @@ export const FileDisplay = ({ file, onDelete, downloadUrl }: FileDisplayProps) =
         fitted
         color="grey"
         onClick={() => onDelete(key)}
+        className="delete-icon"
         style={{ position: 'absolute', right: 0, top: 0 }}
       />
     </List.Item>

--- a/src/formElementPlugins/fileUpload/src/components/FileDisplayWIthDescription.tsx
+++ b/src/formElementPlugins/fileUpload/src/components/FileDisplayWIthDescription.tsx
@@ -18,12 +18,13 @@ export const FileDisplayWithDescription = ({
   const { loading, error, errorMessage, filename, fileData, key } = file
   const [description, setDescription] = useState<string>(fileData?.description ?? '')
   return (
-    <List.Item className="file-item">
+    <List.Item>
       {fileData && (
         <div style={{ display: 'flex', gap: 20, alignItems: 'center', paddingRight: 20 }}>
           <Grid
             verticalAlign="top"
             celled
+            className="file-item"
             style={{ position: 'relative', boxShadow: 'none', maxWidth: '30%' }}
           >
             {error && (

--- a/src/formElementPlugins/fileUpload/src/components/FileDisplayWIthDescription.tsx
+++ b/src/formElementPlugins/fileUpload/src/components/FileDisplayWIthDescription.tsx
@@ -18,7 +18,7 @@ export const FileDisplayWithDescription = ({
   const { loading, error, errorMessage, filename, fileData, key } = file
   const [description, setDescription] = useState<string>(fileData?.description ?? '')
   return (
-    <List.Item>
+    <List.Item className="file-item">
       {fileData && (
         <div style={{ display: 'flex', gap: 20, alignItems: 'center', paddingRight: 20 }}>
           <Grid
@@ -84,6 +84,7 @@ export const FileDisplayWithDescription = ({
               fitted
               color="grey"
               onClick={() => onDelete(key)}
+              className="delete-icon"
               style={{ position: 'absolute', right: 0, top: 0 }}
             />
           </Grid>

--- a/src/formElementPlugins/fileUpload/src/components/FileDisplayWIthDescription.tsx
+++ b/src/formElementPlugins/fileUpload/src/components/FileDisplayWIthDescription.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react'
+import { Button, Icon, Grid, List, Image, Message, Segment, Loader, Input } from 'semantic-ui-react'
+import { FileResponseData, FileInfo } from '../ApplicationView'
+import { FileDisplayProps } from './FileDisplay'
+import prefs from '../../config.json'
+
+interface FileDisplayDescriptionProps extends FileDisplayProps {
+  description?: string
+  updateDescription: (uniqueId: string, value: string, key: string) => void
+}
+
+export const FileDisplayWithDescription = ({
+  file,
+  onDelete,
+  downloadUrl,
+  updateDescription,
+}: FileDisplayDescriptionProps) => {
+  const { loading, error, errorMessage, filename, fileData, key } = file
+  const [description, setDescription] = useState<string>(fileData?.description ?? '')
+  return (
+    <List.Item>
+      {fileData && (
+        <div style={{ display: 'flex', gap: 20, alignItems: 'center', paddingRight: 20 }}>
+          <Grid
+            verticalAlign="top"
+            celled
+            style={{ position: 'relative', boxShadow: 'none', maxWidth: '30%' }}
+          >
+            {error && (
+              <>
+                <Grid.Row
+                  centered
+                  style={{ boxShadow: 'none', height: 120, padding: 10 }}
+                  verticalAlign="middle"
+                >
+                  <Message negative compact>
+                    <p>{errorMessage}</p>
+                  </Message>
+                </Grid.Row>
+                <Grid.Row centered style={{ boxShadow: 'none' }}>
+                  <p style={{ wordBreak: 'break-word' }}>{filename}</p>
+                </Grid.Row>
+              </>
+            )}
+            {loading && (
+              <>
+                <Grid.Row
+                  centered
+                  style={{ boxShadow: 'none', height: 120 }}
+                  verticalAlign="middle"
+                >
+                  <Loader active size="medium">
+                    Uploading
+                  </Loader>
+                </Grid.Row>
+                <Grid.Row centered style={{ boxShadow: 'none' }}>
+                  <p style={{ wordBreak: 'break-word' }}>{filename}</p>
+                </Grid.Row>
+              </>
+            )}
+            {fileData && (
+              <>
+                <Grid.Row centered style={{ boxShadow: 'none' }} verticalAlign="top">
+                  <a href={downloadUrl + fileData.fileUrl} target="_blank">
+                    <Image
+                      src={downloadUrl + fileData.thumbnailUrl}
+                      style={{ maxHeight: prefs.applicationViewThumbnailHeight }}
+                    />
+                  </a>
+                </Grid.Row>
+                <Grid.Row centered style={{ boxShadow: 'none' }}>
+                  <p style={{ wordBreak: 'break-word', fontSize: '90%' }}>
+                    <a href={downloadUrl + fileData.fileUrl} target="_blank">
+                      {filename}
+                    </a>
+                  </p>
+                </Grid.Row>
+              </>
+            )}
+            <Icon
+              link
+              name="delete"
+              circular
+              fitted
+              color="grey"
+              onClick={() => onDelete(key)}
+              style={{ position: 'absolute', right: 0, top: 0 }}
+            />
+          </Grid>
+          {fileData && (
+            <Input
+              fluid
+              placeholder={'Add description'}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              onBlur={(e: any) => updateDescription(fileData.uniqueId, e.target.value, key)}
+            />
+          )}
+        </div>
+      )}
+    </List.Item>
+  )
+}

--- a/src/formElementPlugins/fileUpload/src/components/index.ts
+++ b/src/formElementPlugins/fileUpload/src/components/index.ts
@@ -1,0 +1,2 @@
+export * from './FileDisplay'
+export * from './FileDisplayWIthDescription'

--- a/src/formElementPlugins/fileUpload/src/components/styles.css
+++ b/src/formElementPlugins/fileUpload/src/components/styles.css
@@ -1,0 +1,10 @@
+/* This allows the delete (x) icon to become visible when hovering over the
+whole file icon block */
+
+.delete-icon {
+    visibility: hidden;
+}
+
+.file-item:hover .delete-icon {
+    visibility: visible;
+}

--- a/src/formElementPlugins/fileUpload/src/styles.css
+++ b/src/formElementPlugins/fileUpload/src/styles.css
@@ -1,3 +1,0 @@
-.file-list {
-    /* background-color: green; */
-}

--- a/src/formElementPlugins/fileUpload/src/styles.css
+++ b/src/formElementPlugins/fileUpload/src/styles.css
@@ -1,0 +1,3 @@
+.file-list {
+    /* background-color: green; */
+}


### PR DESCRIPTION
Requires back-end [PR #778](https://github.com/openmsupply/conforma-server/pull/778)

Will be required for the file management template outlined in https://github.com/openmsupply/conforma-web-app/issues/1177.

### Improvements: 

- Plugin can optionally show a "description" input field for each file, which we update on the server without re-uploading file (specify `showDescription: true` parameter)
- Split Display components into seperate files just for easier code management
- "Delete" icon now only shows when hovering over the file, which looks *way* better

Here's a template that shows the fileUpload plugin with the "showDescription" field on:
[fileUpload.zip](https://github.com/openmsupply/conforma-web-app/files/9042764/fileUpload.zip)

