### PR TITLE
#1242 Drop-down custom option tweak

### DIFF
--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -244,7 +244,7 @@ _Multi-choice question, with one allowed option, displayed as Drop-down list (Co
 - **default**: `string`/`number` -- if not provided, defaults to index 0.
 - **search**: `boolean` (default: `false`) -- if `true`, the list of options can be searched and filtered by user
 - **optionsDisplayProperty**: If `options` (above) consists of an array of objects, this parameter specifies the field of each object to be displayed in the options list. For example, if `options` was a list of organisation objects (i.e. `{orgId, name, licenceNumber}`), you'd probably specify `name` as the `optionsDisplayProperty`. Note that even though one field is displayed to the user in the Dropdown list, the _entire_ selected object is saved as the selection. And if `optionsDisplayProperty` refers to a field that doesn't exist on the supplied object, the plugin will fail and show in error in the application.
-- **hasOther**: `boolean` (default `false`) -- if `true`, displays an additional "Other" option with a free text field for inputting additional user-defined option.
+- **hasOther**: `boolean` (default `false`) -- if `true`, allows the user to enter a custom "free text" value instead of one of the pre-defined options.
 
 #### Response type
 
@@ -253,6 +253,7 @@ _Multi-choice question, with one allowed option, displayed as Drop-down list (Co
   optionIndex: <integer> (index from the options array)
   text: <string> (actual text from options array)
   selection: <string | object> (entire object or string from the supplied options list)
+  isCustomOption: <boolean> (if the selection is a custom "hasOther" option)
 }
 
 ```

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -256,7 +256,7 @@ value. Number is assumed to be index, else it returns the index of the
 specified value in the options array. Functions is passed as prop to
 element plug-ins so can be used by any plugin.
 */
-const getDefaultIndex = (defaultOption: string | number, options: string[]) => {
+const getDefaultIndex = (defaultOption: string | number, options: string[]): number => {
   if (typeof defaultOption === 'number') {
     return defaultOption
   } else return options.indexOf(defaultOption)

--- a/src/formElementPlugins/dropdownChoice/localisation/default/strings.json
+++ b/src/formElementPlugins/dropdownChoice/localisation/default/strings.json
@@ -1,0 +1,3 @@
+{
+  "ADD_CUSTOM_OPTION_LABEL": "Add custom value: "
+}

--- a/src/formElementPlugins/dropdownChoice/localisation/pt_an/strings.json
+++ b/src/formElementPlugins/dropdownChoice/localisation/pt_an/strings.json
@@ -1,0 +1,3 @@
+{
+  "ADD_CUSTOM_OPTION_LABEL": "Adicionar valor personalizado: "
+}

--- a/src/formElementPlugins/types.ts
+++ b/src/formElementPlugins/types.ts
@@ -36,7 +36,7 @@ interface ApplicationViewProps extends ApplicationViewWrapperProps {
   setIsActive: () => void
   validationState: ValidationState
   Markdown: any
-  getDefaultIndex: Function
+  getDefaultIndex: (defaultValue: string | number, options: any[]) => number
   parameters: any // TODO: Create type for existing pre-defined types for parameters (TemplateElement)s
   validate: Function
 }


### PR DESCRIPTION
@fergie-nz -- this is branched from your one so you can compare it against what you already had.

See inline comments for more info.

Was a bit trickier than I initially thought. Basic functionality not too bad, the hard part was getting it to recognise and display a custom option when loading, when the options list isn't immediately available -- e.g. from an API.

Here's an alt version of the feature showcase to test against: [Demo-FeatureShowcase_NEW.zip](https://github.com/openmsupply/conforma-web-app/files/9237502/Demo-FeatureShowcase_NEW.zip)
 
In particular -- check out the drop-down at the top of page 5, where it displays a list of names from public API. Now you can add your own custom option and it will still persist even when reloading the page and waiting for the options list.

@fergie-nz you can merge this into your branch when you're happy with it. Feel free to leave it till you're back in the office if you want to clarify anything with me.