### PR TITLE
Quick fix for faulty applicationData.config

### DIFF
--- a/src/utils/helpers/endpoints/endpointUrlBuilder.ts
+++ b/src/utils/helpers/endpoints/endpointUrlBuilder.ts
@@ -25,7 +25,7 @@ const {
 const { port, hostname, protocol } = window.location
 const getProductionUrl = (path: string) => `${protocol}//${hostname}:${port}${path}`
 
-const serverREST = isProductionBuild ? getProductionUrl(productionPathREST) : devServerRest
+export const serverREST = isProductionBuild ? getProductionUrl(productionPathREST) : devServerRest
 export const serverGraphQL = isProductionBuild
   ? getProductionUrl(productionPathGraphQL)
   : devServerGraphQL

--- a/src/utils/hooks/useLoadApplication.ts
+++ b/src/utils/hooks/useLoadApplication.ts
@@ -12,7 +12,6 @@ import evaluate from '@openmsupply/expression-evaluator'
 import { useUserState } from '../../contexts/UserState'
 import { EvaluatorParameters } from '../types'
 import {
-  Application,
   ApplicationStageStatusAll,
   ApplicationStatus,
   Organisation,
@@ -29,7 +28,7 @@ import { buildSectionsStructure } from '../helpers/structure'
 import config from '../../config'
 import { getSectionDetails } from '../helpers/application/getSectionsDetails'
 import useTriggers from './useTriggers'
-import getServerUrl from '../helpers/endpoints/endpointUrlBuilder'
+import getServerUrl, { serverGraphQL, serverREST } from '../helpers/endpoints/endpointUrlBuilder'
 
 const graphQLEndpoint = getServerUrl('graphQL')
 const JWT = localStorage.getItem(config.localStorageJWTKey)
@@ -130,7 +129,13 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
       hasPreviewActions: application.template.previewActions.totalCount > 0,
       user: application?.user as User,
       org: application?.org as Organisation,
-      config: { ...config, getServerUrl },
+      config: {
+        serverGraphQL,
+        serverREST,
+        getServerUrl,
+        isProductionBuild: config.isProductionBuild,
+        version: config.version,
+      },
     }
 
     const baseElements: ElementBase[] = []


### PR DESCRIPTION
Have manually re-constructed the "config" object in applicationData, so it provides "serverREST" prop and "serverGraphQL" prop as before.