### PR TITLE
#1278 Password reset fix (again!)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-json-view": "^1.21.3",
     "react-markdown": "^5.0.3",
     "react-progress-stepper": "^0.2.2",
-    "react-router-dom": "^5.2.0",
+    "react-router-dom": "^5.3.3",
     "react-semantic-ui-datepickers": "^2.13.1",
     "react-string-replace": "^0.4.4",
     "serve": "^11.3.2"

--- a/src/components/Review/DecisionPreview/ReviewPreviewModal.tsx
+++ b/src/components/Review/DecisionPreview/ReviewPreviewModal.tsx
@@ -44,7 +44,7 @@ const ReviewPreviewModal: React.FC<PreviewProps> = ({
     // generates new Previews every time it's opened
     <Modal id="preview-modal" open={open} closeOnDimmerClick={false}>
       <Modal.Header>{strings.REVIEW_DECISION_PREVIEW_HEADER}</Modal.Header>
-      <Modal.Content>
+      <Modal.Content scrolling>
         {strings.REVIEW_DECISION_PREVIEW_TEXT} <strong>{decision}</strong>
         {loading && (
           <Loader active size="huge">

--- a/src/containers/Main/AuthenticatedWrapper.tsx
+++ b/src/containers/Main/AuthenticatedWrapper.tsx
@@ -1,21 +1,18 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import SiteLayout from './SiteLayout'
 import { useRouter } from '../../utils/hooks/useRouter'
 import isLoggedIn from '../../utils/helpers/loginCheck'
 import NonRegisteredLogin from '../User/NonRegisteredLogin'
 import { Redirect } from 'react-router'
-import { Loading } from '../../components'
 
 const AuthenticatedContent: React.FC = () => {
-  const {
-    location,
-    query: { sessionId },
-  } = useRouter()
-  // Location is not fully loaded unless 'state' is present, TODO try upgrading react router
-  // without this sessionId is missing when navigating via Click Here in forgot password verification
-  // if ('state' in location) {
+  const { location } = useRouter()
+
+  const sessionId = getSessionIdFromUrl()
+
   console.log('Location state', location)
   console.log('sessionId', sessionId)
+
   let { pathname, search } = location
   // If there is a sessionId in the URL, then need to login as nonRegistered
   // before continuing
@@ -29,9 +26,18 @@ const AuthenticatedContent: React.FC = () => {
   }
   console.log('REDIRECT to login')
   return <Redirect to={{ pathname: '/login', state: { from: location.pathname } }} />
-  // }
-  console.log('Default loading...')
-  return <Loading />
 }
 
 export default AuthenticatedContent
+
+// This is a nasty hack that we need due to the fact that ReactRouter doesn't
+// have "query" values available when this component is loaded from another. So
+// we fetch and parse it ourselves directly from window.location.search instead.
+// We should upgrade to ReactRouter 6 at some point and hopefully this will be
+// sorted.
+export const getSessionIdFromUrl = () => {
+  const sessionIdRegex = /^\?(sessionId)=(.+)$/
+  const matches = window.location.search.match(sessionIdRegex)
+  if (!matches) return null
+  if (matches[1] === 'sessionId') return matches[2]
+}

--- a/src/containers/Main/AuthenticatedWrapper.tsx
+++ b/src/containers/Main/AuthenticatedWrapper.tsx
@@ -10,30 +10,24 @@ const AuthenticatedContent: React.FC = () => {
 
   const sessionId = getSessionIdFromUrl()
 
-  console.log('Location state', location)
-  console.log('sessionId', sessionId)
-
   let { pathname, search } = location
   // If there is a sessionId in the URL, then need to login as nonRegistered
   // before continuing
-  if (sessionId && !isLoggedIn()) {
-    console.log('SessionID and logged in')
+  if (sessionId && !isLoggedIn())
     return <NonRegisteredLogin option="redirect" redirect={pathname + search} />
-  }
-  if (isLoggedIn()) {
-    console.log('isLoggedIn, authenticated')
-    return <SiteLayout />
-  }
-  console.log('REDIRECT to login')
+
+  if (isLoggedIn()) return <SiteLayout />
+
   return <Redirect to={{ pathname: '/login', state: { from: location.pathname } }} />
 }
 
 export default AuthenticatedContent
 
 // This is a nasty hack that we need due to the fact that ReactRouter doesn't
-// have "query" values available when this component is loaded from another. So
-// we fetch and parse it ourselves directly from window.location.search instead.
-// We should upgrade to ReactRouter 6 at some point and hopefully this will be
+// have "query" values available when this component is loaded from another
+// (i.e. when clicking "Click here" in password reset verification). So we fetch
+// and parse it ourselves directly from window.location.search instead. We
+// should upgrade to ReactRouter 6 at some point and hopefully this will be
 // sorted.
 export const getSessionIdFromUrl = () => {
   const sessionIdRegex = /^\?(sessionId)=(.+)$/

--- a/src/containers/Main/AuthenticatedWrapper.tsx
+++ b/src/containers/Main/AuthenticatedWrapper.tsx
@@ -10,7 +10,8 @@ const AuthenticatedContent: React.FC = () => {
 
   const sessionId = getSessionIdFromUrl()
 
-  let { pathname, search } = location
+  const { pathname, search } = location
+
   // If there is a sessionId in the URL, then need to login as nonRegistered
   // before continuing
   if (sessionId && !isLoggedIn())

--- a/src/containers/Main/AuthenticatedWrapper.tsx
+++ b/src/containers/Main/AuthenticatedWrapper.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import SiteLayout from './SiteLayout'
 import { useRouter } from '../../utils/hooks/useRouter'
 import isLoggedIn from '../../utils/helpers/loginCheck'
@@ -13,15 +13,24 @@ const AuthenticatedContent: React.FC = () => {
   } = useRouter()
   // Location is not fully loaded unless 'state' is present, TODO try upgrading react router
   // without this sessionId is missing when navigating via Click Here in forgot password verification
-  if ('state' in location) {
-    let { pathname, search } = location
-    // If there is a sessionId in the URL, then need to login as nonRegistered
-    // before continuing
-    if (sessionId) return <NonRegisteredLogin option="redirect" redirect={pathname + search} />
-    if (isLoggedIn()) return <SiteLayout />
-    return <Redirect to={{ pathname: '/login', state: { from: location.pathname } }} />
+  // if ('state' in location) {
+  console.log('Location state', location)
+  console.log('sessionId', sessionId)
+  let { pathname, search } = location
+  // If there is a sessionId in the URL, then need to login as nonRegistered
+  // before continuing
+  if (sessionId && !isLoggedIn()) {
+    console.log('SessionID and logged in')
+    return <NonRegisteredLogin option="redirect" redirect={pathname + search} />
   }
-
+  if (isLoggedIn()) {
+    console.log('isLoggedIn, authenticated')
+    return <SiteLayout />
+  }
+  console.log('REDIRECT to login')
+  return <Redirect to={{ pathname: '/login', state: { from: location.pathname } }} />
+  // }
+  console.log('Default loading...')
   return <Loading />
 }
 

--- a/src/containers/User/NonRegisteredLogin.tsx
+++ b/src/containers/User/NonRegisteredLogin.tsx
@@ -29,8 +29,7 @@ const NonRegisteredLogin: React.FC<NonRegisteredLoginProps> = ({ option, redirec
     // Log in as 'nonRegistered' user to be able to apply for User Registration
     // form or reset password
 
-    const sessionId = getSessionIdFromUrl() ?? ''
-    console.log('Attempting login with', sessionId)
+    const sessionId = getSessionIdFromUrl() ?? undefined
 
     attemptLogin({
       username: config.nonRegisteredUser,

--- a/src/containers/User/NonRegisteredLogin.tsx
+++ b/src/containers/User/NonRegisteredLogin.tsx
@@ -22,14 +22,21 @@ const NonRegisteredLogin: React.FC<NonRegisteredLoginProps> = ({ option, redirec
   } = useRouter()
   const { onLogin } = useUserState()
 
+  console.log('SessionId', sessionId)
+
   // useEffect ensures isLoggedIn only runs on first mount, not re-renders
   useEffect(() => {
-    if (isLoggedIn()) push('/')
+    console.log('Checking login...')
+    if (isLoggedIn()) {
+      console.log('Logged in!')
+      push('/')
+    }
   }, [])
 
   useEffect(() => {
     // Log in as 'nonRegistered' user to be able to apply for User Registration
     // form or reset password
+    console.log('Attempting login with', sessionId)
 
     attemptLogin({
       username: config.nonRegisteredUser,
@@ -42,11 +49,16 @@ const NonRegisteredLogin: React.FC<NonRegisteredLoginProps> = ({ option, redirec
   }, [])
 
   const onLoginSuccess = async (loginResult: LoginPayload) => {
+    console.log('Success')
+    console.log('Option', option)
     const { JWT, user, templatePermissions, orgList, isAdmin } = loginResult
     await onLogin(JWT, user, templatePermissions, orgList, isAdmin)
     if (option === 'register') push('/application/new?type=UserRegistration')
     else if (option === 'reset-password') push('/application/new?type=PasswordReset')
-    else if (option === 'redirect' && redirect) push(redirect)
+    else if (option === 'redirect' && redirect) {
+      console.log('Redirecting', redirect)
+      push(redirect)
+    }
   }
 
   if (networkError) return <p>{networkError}</p>

--- a/src/containers/User/NonRegisteredLogin.tsx
+++ b/src/containers/User/NonRegisteredLogin.tsx
@@ -22,6 +22,9 @@ const NonRegisteredLogin: React.FC<NonRegisteredLoginProps> = ({ option, redirec
 
   // useEffect ensures isLoggedIn only runs on first mount, not re-renders
   useEffect(() => {
+    // Don't let a logged in user go to register page, but they can go to
+    // "reset-password"
+    if (option === 'reset-password') return
     if (isLoggedIn()) push('/')
   }, [])
 

--- a/src/containers/User/NonRegisteredLogin.tsx
+++ b/src/containers/User/NonRegisteredLogin.tsx
@@ -6,6 +6,7 @@ import { useUserState } from '../../contexts/UserState'
 import { useLanguageProvider } from '../../contexts/Localisation'
 import { LoginPayload } from '../../utils/types'
 import config from '../../config'
+import { getSessionIdFromUrl } from '../Main/AuthenticatedWrapper'
 
 interface NonRegisteredLoginProps {
   option: 'register' | 'reset-password' | 'redirect'
@@ -16,26 +17,19 @@ const NonRegisteredLogin: React.FC<NonRegisteredLoginProps> = ({ option, redirec
   const { strings } = useLanguageProvider()
 
   const [networkError, setNetworkError] = useState('')
-  const {
-    push,
-    query: { sessionId },
-  } = useRouter()
+  const { push } = useRouter()
   const { onLogin } = useUserState()
-
-  console.log('SessionId', sessionId)
 
   // useEffect ensures isLoggedIn only runs on first mount, not re-renders
   useEffect(() => {
-    console.log('Checking login...')
-    if (isLoggedIn()) {
-      console.log('Logged in!')
-      push('/')
-    }
+    if (isLoggedIn()) push('/')
   }, [])
 
   useEffect(() => {
     // Log in as 'nonRegistered' user to be able to apply for User Registration
     // form or reset password
+
+    const sessionId = getSessionIdFromUrl() ?? ''
     console.log('Attempting login with', sessionId)
 
     attemptLogin({
@@ -49,16 +43,11 @@ const NonRegisteredLogin: React.FC<NonRegisteredLoginProps> = ({ option, redirec
   }, [])
 
   const onLoginSuccess = async (loginResult: LoginPayload) => {
-    console.log('Success')
-    console.log('Option', option)
     const { JWT, user, templatePermissions, orgList, isAdmin } = loginResult
     await onLogin(JWT, user, templatePermissions, orgList, isAdmin)
     if (option === 'register') push('/application/new?type=UserRegistration')
     else if (option === 'reset-password') push('/application/new?type=PasswordReset')
-    else if (option === 'redirect' && redirect) {
-      console.log('Redirecting', redirect)
-      push(redirect)
-    }
+    else if (option === 'redirect' && redirect) push(redirect)
   }
 
   if (networkError) return <p>{networkError}</p>

--- a/src/utils/helpers/endpoints/types.ts
+++ b/src/utils/helpers/endpoints/types.ts
@@ -40,7 +40,7 @@ export type CheckUniqueEndpoint = [
         table: string
         field: string
       }
-  ) & { value: string }
+  ) & { value: string; caseInsensitive?: boolean }
 ]
 
 export type DataViewEndpoint = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,6 +486,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.13":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -7294,23 +7301,25 @@ react-progress-stepper@^0.2.2:
   dependencies:
     styled-components "^5.3.0"
 
-react-router-dom@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
+react-router-dom@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.3.tgz#8779fc28e6691d07afcaf98406d3812fe6f11199"
+  integrity sha512-Ov0tGPMBgqmbu5CDmN++tv2HQ9HlWDuWIIqn4b88gjlAN5IHI+4ZUZRcpz9Hl0azFIwihbLDYw1OiHGRo7ZIng==
   dependencies:
-    "@babel/runtime" "^7.1.2"
+    "@babel/runtime" "^7.12.13"
     history "^4.9.0"
     loose-envify "^1.3.1"
     prop-types "^15.6.2"
-    react-router "5.2.0"
+    react-router "5.3.3"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
+react-router@5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.3.3.tgz#8e3841f4089e728cf82a429d92cdcaa5e4a3a288"
+  integrity sha512-mzQGUvS3bM84TnbtMYR8ZjKnuPJ71IjSzR+DE6UkUqvN4czWIqEs17yLL8xkAycv4ev0AiN+IGrWu88vJs/p2w==
   dependencies:
-    "@babel/runtime" "^7.1.2"
+    "@babel/runtime" "^7.12.13"
     history "^4.9.0"
     hoist-non-react-statics "^3.1.0"
     loose-envify "^1.3.1"


### PR DESCRIPTION
Fix #1278

Yikes, this was a bit gnarly. @andreievg I'd be interested to see what you think and if there's a better way to go about it.

Basically, the problem with the solution you made a couple of weeks ago is that, if `state` is not present at the beginning, then even though you accounted for the case, your solution relied on "location" changing and forcing a re-render of the `AuthenticatedWrapper` component. Unfortunately, this doesn't happen, and so it just sits there perpetually re-loading.

Seems like whatever bug/issue is causing the "location" object to be missing "state", and "query" on load is also not notifying React of a change when it *is* available.

So I went with a blunt solution -- ignore React Router completely and DIY it with my own function to manually parse `window.location`. It works, but it sucks that we need to resort to this -- surely there's a better way? 

Couple of tiny offroad fixes too. See inline comments for more.