### PR TITLE
#1278 Password reset fix again again!

### DIFF
--- a/src/containers/Main/AuthenticatedWrapper.tsx
+++ b/src/containers/Main/AuthenticatedWrapper.tsx
@@ -6,15 +6,13 @@ import NonRegisteredLogin from '../User/NonRegisteredLogin'
 import { Redirect } from 'react-router'
 
 const AuthenticatedContent: React.FC = () => {
-  const { location } = useRouter()
-
-  const sessionId = getSessionIdFromUrl()
+  const { location, query } = useRouter()
 
   const { pathname, search } = location
 
   // If there is a sessionId in the URL, then need to login as nonRegistered
   // before continuing
-  if (sessionId && !isLoggedIn())
+  if (query.sessionId && !isLoggedIn())
     return <NonRegisteredLogin option="redirect" redirect={pathname + search} />
 
   if (isLoggedIn()) return <SiteLayout />
@@ -23,16 +21,3 @@ const AuthenticatedContent: React.FC = () => {
 }
 
 export default AuthenticatedContent
-
-// This is a nasty hack that we need due to the fact that ReactRouter doesn't
-// have "query" values available when this component is loaded from another
-// (i.e. when clicking "Click here" in password reset verification). So we fetch
-// and parse it ourselves directly from window.location.search instead. We
-// should upgrade to ReactRouter 6 at some point and hopefully this will be
-// sorted.
-export const getSessionIdFromUrl = () => {
-  const sessionIdRegex = /^\?(sessionId)=(.+)$/
-  const matches = window.location.search.match(sessionIdRegex)
-  if (!matches) return null
-  if (matches[1] === 'sessionId') return matches[2]
-}

--- a/src/containers/User/NonRegisteredLogin.tsx
+++ b/src/containers/User/NonRegisteredLogin.tsx
@@ -6,7 +6,6 @@ import { useUserState } from '../../contexts/UserState'
 import { useLanguageProvider } from '../../contexts/Localisation'
 import { LoginPayload } from '../../utils/types'
 import config from '../../config'
-import { getSessionIdFromUrl } from '../Main/AuthenticatedWrapper'
 
 interface NonRegisteredLoginProps {
   option: 'register' | 'reset-password' | 'redirect'
@@ -17,7 +16,7 @@ const NonRegisteredLogin: React.FC<NonRegisteredLoginProps> = ({ option, redirec
   const { strings } = useLanguageProvider()
 
   const [networkError, setNetworkError] = useState('')
-  const { push } = useRouter()
+  const { push, query } = useRouter()
   const { onLogin } = useUserState()
 
   // useEffect ensures isLoggedIn only runs on first mount, not re-renders
@@ -32,12 +31,10 @@ const NonRegisteredLogin: React.FC<NonRegisteredLoginProps> = ({ option, redirec
     // Log in as 'nonRegistered' user to be able to apply for User Registration
     // form or reset password
 
-    const sessionId = getSessionIdFromUrl() ?? undefined
-
     attemptLogin({
       username: config.nonRegisteredUser,
       password: '',
-      sessionId,
+      sessionId: (query.sessionId as string) ?? undefined,
       onLoginSuccess,
     }).catch((error) => {
       setNetworkError(error.message)


### PR DESCRIPTION
Hmmm, prompted by @andreievg 's comment [here](https://github.com/openmsupply/conforma-web-app/pull/1280/files#r944026127), I looked into this a little bit more. Our custom `useRouter` hook is already using the suggested "queryString" to fetch the url queries, and it seems that "query" is actually available when clicking through, even when "state" is missing.

I now think that the thing that was wrong was not actually the missing "sessionId", but was due to the fact that there was an `isLoggedIn()` check on load of the "NonRegisteredLogin" component, and if you were already logged in as "nonRegistered" (which you would be after filling in a password reset request) then you'd get re-directed away back to the login screen.

I think the missing "state"  / "sesssionId" was actually a bit of a red herring

I already made a fix in that last PR to allow a logged-in user to go to the "password_reset" page, and I now think that this is enough to prevent the re-direction.

So I've reverted the `AuthenticatedWrapper` to use "query" from useRouter, and I've left this other little change:
```
  if (query.sessionId && !isLoggedIn())
    return <NonRegisteredLogin option="redirect" redirect={pathname + search} />
```
So now it only re-logs you in if you're not already logged in (as nonRegistered). If you are, it just loads `<SiteLayout/>` with the password reset application correctly.

I can't find any situations where this doesn't work now. Have tried:
- Forgot password, then logging out (clear local storage) BEFORE verification and PW reset
- Forgot password, then verifying and reset without logging out
- Create internal user, verifying and resetting password as separate user WITHOUT logging staff member out
- Create internal user, verifying and resetting password AFTER logging out

Please let me know if you find any.