### PR TITLE
#1294 fixing failing to load

### DIFF
--- a/src/components/List/Cells/OutcomeCell.tsx
+++ b/src/components/List/Cells/OutcomeCell.tsx
@@ -21,8 +21,9 @@ const useOutcomeDisplayMap = () => {
 const OutcomeCell: React.FC<CellProps> = ({ application }) => {
   const outcomeDisplayMap = useOutcomeDisplayMap()
   const { outcome } = application
+  console.log(outcome)
 
-  if (outcome === ApplicationOutcome.Pending) return null
+  if (outcome === ApplicationOutcome.Pending || outcome === null) return null
   // Only show label if no longer in progress
   else {
     const { icon, color, text } = outcomeDisplayMap[outcome as ApplicationOutcome]

--- a/src/components/List/Cells/OutcomeCell.tsx
+++ b/src/components/List/Cells/OutcomeCell.tsx
@@ -21,7 +21,6 @@ const useOutcomeDisplayMap = () => {
 const OutcomeCell: React.FC<CellProps> = ({ application }) => {
   const outcomeDisplayMap = useOutcomeDisplayMap()
   const { outcome } = application
-  console.log(outcome)
 
   if (outcome === ApplicationOutcome.Pending || outcome === null) return null
   // Only show label if no longer in progress


### PR DESCRIPTION
outcome is initially returning as null in stead of PENDING. I am unsure exactly why this is. 

This catches this error and delays render attempt until outcome is returning a value