### PR TITLE
#1298 Checkbox improvements

### DIFF
--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -331,17 +331,18 @@ To handle objects returned that don't have the required fields, you can use the 
 - **type**: `string` -- Can be "toggle" to display as a toggle switch, or "slider" to display as a slider switch (defaults to regular checkbox).
 - **layout**: `string` -- if "inline", displays checkboxes horizontally in rows. Useful if there are a lot of checkboxes.
 - **resetButton**: `boolean` -- if `true`, element will show a "Reset" button, which allows user to reset selections to the initial (loading) state. (Default: `false`)
-- **textDisplay**: (Options: `text`, `list` (default), `propertyList`) -- specifies how to show the applicant's response on the Summary page:
+- **displayFormat**: (Options: `text`, `list` (default), `checkboxes`, `propertyList`) -- specifies how to show the applicant's response on the Summary page:
   - `list`: shows the selected checkboxes in a (Markdown) list
   - `text`: shows the selected values in a comma-seperated text string
+  - `checkboxes`: displays the selected values as checkboxes as per the application view
   - `propertyList`: displays in a list with properties (the checkbox `label` field) and values (the checkbox `text` or `textNegative` values, depending on selection).  
-  e.g.  
-    – Option1: YES
+  e.g.
+    - Option1: YES
     - Option 2: NO
     - \<checkbox `label`\>: \<`text`\/`textNegative` value\>  
-Note: this display option is only suitable if you have separately defined `label`, `text` and `textNegative` fields for each checkbox. 
-- **keyMap**: `object` -- if the input `checkboxes` property (above) has different property names that what is required (for example, if pulling from an API), then this `keyMap` parameter can be used to re-map the input property names to the requried property names. For example, if your input "checkbox" data contained an array of objects of the type `{ name: "Nicole", active: true}`, you would provide a `keyMap` object like this:
+Note: this display option is only suitable if you have separately defined `label`, `text` and `textNegative` fields for each checkbox.
 - **preventNonResponse**: `boolean` (default `false`) -- normally, we want to allow the user to leave checkboxes unchecked and be considered a valid response. However, if we want to force the user to tick a box (e.g. for a declaration, say), then set `preventNonResponse` to `true`.
+- **keyMap**: `object` -- if the input `checkboxes` property (above) has different property names that what is required (for example, if pulling from an API), then this `keyMap` parameter can be used to re-map the input property names to the requried property names. For example, if your input "checkbox" data contained an array of objects of the type `{ name: "Nicole", active: true}`, you would provide a `keyMap` object like this:
 ```
 {
   label: "name",

--- a/semantic/src/site/globals/site.variables
+++ b/semantic/src/site/globals/site.variables
@@ -50,6 +50,9 @@
 @headersInteractiveMed: #656565;
 @borderColourDark: #777777;
 @activeCommentBackground: azure;
+@inputPlaceholderColor: lighten(@inputColor, 20);
+@inputPlaceholderFocusColor: lighten(@inputColor, 40);
+@disabledOpacity: 0.75;
 //
 @boxShadowColor: #d4d4d5;
 @fullyTransperant: rgba(0, 0, 0, 0);

--- a/src/formElementPlugins/checkbox/src/ApplicationView.tsx
+++ b/src/formElementPlugins/checkbox/src/ApplicationView.tsx
@@ -4,7 +4,7 @@ import { ApplicationViewProps } from '../../types'
 import { useLanguageProvider } from '../../../contexts/Localisation'
 import config from '../pluginConfig.json'
 
-interface Checkbox {
+export interface Checkbox {
   label: string
   text: string
   textNegative?: string
@@ -12,9 +12,42 @@ interface Checkbox {
   selected: boolean
 }
 
-interface CheckboxSavedState {
+export interface CheckboxSavedState {
   text: string
   values: { [key: string]: Checkbox }
+}
+
+export const CheckboxDisplay: React.FC<{
+  checkboxes: Checkbox[]
+  disabled: boolean
+  type: string
+  layout: string
+  onChange: (e: any, data: any) => void
+}> = ({ checkboxes, disabled, type, layout, onChange }) => {
+  const styles =
+    layout === 'inline'
+      ? {
+          display: 'inline',
+          marginRight: 10,
+        }
+      : {}
+
+  return (
+    <>
+      {checkboxes.map((cb: Checkbox, index: number) => (
+        <Form.Field key={`${index}_${cb.label}`} disabled={disabled} style={styles}>
+          <Checkbox
+            label={cb.label}
+            checked={cb.selected}
+            onChange={onChange}
+            index={index}
+            toggle={type === 'toggle'}
+            slider={type === 'slider'}
+          />
+        </Form.Field>
+      ))}
+    </>
+  )
 }
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
@@ -42,7 +75,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const [isFirstRender, setIsFirstRender] = useState(true)
 
   const [checkboxElements, setCheckboxElements] = useState<Checkbox[]>(
-    getInitialState(initialValue, checkboxes, keyMap, isFirstRender)
+    getCheckboxStructure(initialValue, checkboxes, keyMap, isFirstRender)
   )
 
   // When checkbox array changes after initial load (e.g. when its being dynamically loaded from an API)
@@ -50,7 +83,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     if (checkboxes[0] !== config.parameterLoadingValues.label && isFirstRender) {
       setIsFirstRender(false)
     }
-    setCheckboxElements(getInitialState(initialValue, checkboxes, keyMap, isFirstRender))
+    setCheckboxElements(getCheckboxStructure(initialValue, checkboxes, keyMap, isFirstRender))
   }, [checkboxes])
 
   useEffect(() => {
@@ -92,15 +125,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   }
 
   const resetState = () =>
-    setCheckboxElements(getInitialState(initialValue, checkboxes, keyMap, isFirstRender))
-
-  const styles =
-    layout === 'inline'
-      ? {
-          display: 'inline',
-          marginRight: 10,
-        }
-      : {}
+    setCheckboxElements(getCheckboxStructure(initialValue, checkboxes, keyMap, isFirstRender))
 
   return (
     <>
@@ -110,18 +135,13 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         </label>
       )}
       <Markdown text={description} />
-      {checkboxElements.map((cb: Checkbox, index: number) => (
-        <Form.Field key={`${index}_${cb.label}`} disabled={!isEditable} style={styles}>
-          <Checkbox
-            label={cb.label}
-            checked={cb.selected}
-            onChange={toggle}
-            index={index}
-            toggle={type === 'toggle'}
-            slider={type === 'slider'}
-          />
-        </Form.Field>
-      ))}
+      <CheckboxDisplay
+        checkboxes={checkboxElements}
+        disabled={!isEditable}
+        type={type}
+        layout={layout}
+        onChange={toggle}
+      />
       {resetButton && (
         <div style={{ marginTop: 10 }}>
           <Button primary content={strings.BUTTON_RESET_SELECTION} compact onClick={resetState} />
@@ -144,7 +164,7 @@ type KeyMap = {
   selected?: string
 }
 
-const getInitialState = (
+export const getCheckboxStructure = (
   initialValue: CheckboxSavedState,
   checkboxes: Checkbox[],
   keyMap: KeyMap | undefined,

--- a/src/formElementPlugins/checkbox/src/ApplicationView.tsx
+++ b/src/formElementPlugins/checkbox/src/ApplicationView.tsx
@@ -80,9 +80,8 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   // When checkbox array changes after initial load (e.g. when its being dynamically loaded from an API)
   useEffect(() => {
-    if (checkboxes[0] !== config.parameterLoadingValues.label && isFirstRender) {
+    if (checkboxes[0] !== config.parameterLoadingValues.label && isFirstRender)
       setIsFirstRender(false)
-    }
     setCheckboxElements(getCheckboxStructure(initialValue, checkboxes, keyMap, isFirstRender))
   }, [checkboxes])
 

--- a/src/formElementPlugins/checkbox/src/SummaryView.tsx
+++ b/src/formElementPlugins/checkbox/src/SummaryView.tsx
@@ -1,27 +1,53 @@
 import React from 'react'
 import { Form } from 'semantic-ui-react'
-import { ResponseFull } from '../../../utils/types'
+import { getCheckboxStructure, CheckboxDisplay } from './ApplicationView'
 import { SummaryViewProps } from '../../types'
 
-enum TextDisplay {
+enum DisplayFormat {
   TEXT = 'text',
   LIST = 'list',
   PROPERTYLIST = 'propertyList',
-}
-
-const getMarkdownText = (textDisplay: string, response: ResponseFull) => {
-  switch (textDisplay) {
-    case TextDisplay.LIST:
-      return response?.textMarkdownList ?? response.text
-    case TextDisplay.PROPERTYLIST:
-      return response?.textMarkdownPropertyList ?? response.text
-    default:
-      return response.text
-  }
+  CHECKBOXES = 'checkboxes',
 }
 
 const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, response }) => {
-  const { textDisplay = TextDisplay.LIST, label, description } = parameters
+  const {
+    displayFormat = DisplayFormat.LIST,
+    label,
+    description,
+    checkboxes,
+    layout,
+    type,
+    keyMap,
+  } = parameters
+  let displayComponent
+  switch (displayFormat) {
+    case DisplayFormat.LIST:
+      displayComponent = (
+        <Markdown text={(response ? response?.textMarkdownList || response.text : '') as string} />
+      )
+      break
+    case DisplayFormat.PROPERTYLIST:
+      displayComponent = (
+        <Markdown
+          text={(response ? response?.textMarkdownPropertyList || response.text : '') as string}
+        />
+      )
+      break
+    case DisplayFormat.CHECKBOXES:
+      displayComponent = response ? (
+        <CheckboxDisplay
+          checkboxes={getCheckboxStructure(response, checkboxes, keyMap, true)}
+          disabled
+          type={type}
+          layout={layout}
+          onChange={() => {}}
+        />
+      ) : null
+      break
+    default:
+      displayComponent = <Markdown text={(response ? response.text : '') as string} />
+  }
   return (
     <Form.Field className="element-summary-view">
       {label && (
@@ -30,7 +56,7 @@ const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, respons
         </label>
       )}
       <Markdown text={description} />
-      <Markdown text={(response ? getMarkdownText(textDisplay, response) : '') as string} />
+      {displayComponent}
     </Form.Field>
   )
 }

--- a/src/formElementPlugins/fileUpload/src/SummaryView.tsx
+++ b/src/formElementPlugins/fileUpload/src/SummaryView.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Grid, Form, Image, List } from 'semantic-ui-react'
-import config from '../../../config'
 import prefs from '../config.json'
 import getServerUrl from '../../../utils/helpers/endpoints/endpointUrlBuilder'
 import { SummaryViewProps } from '../../types'

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -18,6 +18,7 @@ import {
 } from './generated/graphql'
 
 import { ValidationState } from '../formElementPlugins/types'
+import { Checkbox } from '../formElementPlugins/checkbox/src/ApplicationView'
 import { EvaluatorNode } from '@openmsupply/expression-evaluator/lib/types'
 import { SemanticICONS } from 'semantic-ui-react'
 import { DocumentNode } from '@apollo/client'
@@ -360,7 +361,7 @@ interface ApplicationProgress {
 
 interface ResponseFull {
   id: number
-  text: string | null | undefined
+  text: string
   optionIndex?: number
   isValid?: boolean | null
   hash?: string // Used in Password plugin
@@ -371,11 +372,12 @@ interface ResponseFull {
   list?: any // Used in ListBuilder
   date?: any // Used in DatePicker
   number?: number | null // Used in Number plugin
-  // Next 4 used in Checkbox Summary view
+  // Next 5 used in Checkbox Summary view
   textUnselected?: string
   textMarkdownList?: string
   textUnselectedMarkdownList?: string
   textMarkdownPropertyList?: string
+  values: { [key: string]: Checkbox }
   timeCreated?: Date
   reviewResponse?: ReviewResponse
   customValidation?: ValidationState
@@ -824,8 +826,8 @@ export type FilterTypeOptions = {
 
 export type FilterDefinition = {
   type: FilterTypes
-  default: boolean,
-  visibleTo: USER_ROLES[],
+  default: boolean
+  visibleTo: USER_ROLES[]
   // Empty or undefined title will be excluded from generic fitler UI display (ListFilters)
   title?: string
   options?: FilterTypeOptions


### PR DESCRIPTION
Fix #1298 

Changed the name of the "textDisplay" parameter to "displayFormat", and added additional "checkboxes" option to display checkboxes on the Summary page.

Currently the "List" option is the default, which I've left so as to not affect existing templates, but I'm open to changing if we think it's worth it (discuss at next meeting?)

**Update**: Also addressed #1297 a11cbe49