### PR TITLE
1300 Don't display time with deadline

### DIFF
--- a/src/components/List/Cells/DeadlineCell.tsx
+++ b/src/components/List/Cells/DeadlineCell.tsx
@@ -12,12 +12,6 @@ const DeadlineCell: React.FC<CellProps> = ({ application }) => {
   const deadline = DateTime.fromISO(application.applicantDeadline)
   const textColorClass =
     deadline.diff(DateTime.now(), 'days').days < ALERT_FORMAT_DAYS ? 'alert-colour' : ''
-  return (
-    <p className={`slightly-smaller-text ${textColorClass}`}>
-      {deadline.toLocaleString()}
-      <br />
-      {deadline.toLocaleString(DateTime.TIME_SIMPLE)}
-    </p>
-  )
+  return <p className={`slightly-smaller-text ${textColorClass}`}>{deadline.toLocaleString()}</p>
 }
 export default DeadlineCell

--- a/src/containers/Review/overview/Overview.tsx
+++ b/src/containers/Review/overview/Overview.tsx
@@ -83,9 +83,7 @@ export const Overview: React.FC<{
               {applicantDeadline.deadline && applicantDeadline.isActive && (
                 <p className="right-item">
                   <strong>{strings.REVIEW_OVERVIEW_DEADLINE}: </strong>
-                  {DateTime.fromJSDate(applicantDeadline.deadline).toLocaleString(
-                    DateTime.DATETIME_SHORT
-                  )}
+                  {DateTime.fromJSDate(applicantDeadline.deadline).toLocaleString()}
                 </p>
               )}
             </div>


### PR DESCRIPTION
Fix #1300 

Now only shows date on "List" and (review) "Overview" page.

~~Still needs back-end PR to change scheduled check.~~ Should be changed in `preferences.json` now.


(If you want a quick way to test -- use the snapshot `appDeadlineTest_2022_07_16` in templates repo, submit application as "jane_smith" and request changes (as Basic Reviewer))