### PR TITLE
#1291 Fix "Manage" menu bar item

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -51,6 +51,7 @@ const config = {
   localStorageJWTKey: 'persistJWT',
   applicantDeadlineCode: 'applicantDeadline',
   isProductionBuild,
+  defaultSystemManagerPermissionName: 'systemManager',
 }
 
 export default config

--- a/src/contexts/UserState.tsx
+++ b/src/contexts/UserState.tsx
@@ -3,6 +3,7 @@ import { useApolloClient } from '@apollo/client'
 import fetchUserInfo from '../utils/helpers/fetchUserInfo'
 import { OrganisationSimple, TemplatePermissions, User } from '../utils/types'
 import config from '../config'
+import { usePrefs } from '../contexts/SystemPrefs'
 
 type UserState = {
   currentUser: User | null
@@ -103,6 +104,10 @@ export function UserProvider({ children }: UserProviderProps) {
   const userState = state
   const setUserState = dispatch
   const client = useApolloClient()
+  const { preferences } = usePrefs()
+
+  const managementPrefName =
+    preferences?.systemManagerPermissionName || config.defaultSystemManagerPermissionName
 
   const logout = () => {
     // Delete everything EXCEPT language preference in localStorage
@@ -135,7 +140,7 @@ export function UserProvider({ children }: UserProviderProps) {
         newPermissionNames: permissionNames || [],
         newOrgList: orgList || [],
         newIsAdmin: !!isAdmin,
-        newIsManager: false,
+        newIsManager: permissionNames.includes(managementPrefName),
       })
       dispatch({ type: 'setLoading', isLoading: false })
     }

--- a/src/utils/helpers/fetchUserInfo.ts
+++ b/src/utils/helpers/fetchUserInfo.ts
@@ -12,7 +12,8 @@ interface SetUserInfoProps {
 const fetchUserInfo = ({ dispatch }: SetUserInfoProps, logout: Function) => {
   const { preferences } = usePrefs()
 
-  const managementPrefName = preferences?.systemManagerPermissionName || 'systemManager'
+  const managementPrefName =
+    preferences?.systemManagerPermissionName || config.defaultSystemManagerPermissionName
 
   getRequest(getServerUrl('userInfo'))
     .then(({ templatePermissions, permissionNames, JWT, user, success, orgList, isAdmin }) => {


### PR DESCRIPTION
Fix #1291 

It was getting the correct `isManage` pref when already logged in, but when logging in, it would run the `else` part of the `onLogin` method (in UserState), which was setting `isManager` to `false`. I think I assumed it would get updated by a subsequent `fetchUserInfo` call, but it doesn't.

So this just fixes that.