### PR TITLE
Add correct config info to applicationData

### DIFF
--- a/src/containers/DataDisplay/helpers.tsx
+++ b/src/containers/DataDisplay/helpers.tsx
@@ -8,6 +8,7 @@ import { defaultEvaluatedElement } from '../../utils/hooks/useLoadApplication'
 import { TemplateElementCategory } from '../../utils/generated/graphql'
 import { ApplicationDetails } from '../../utils/types'
 import config from '../../config'
+import { serverREST, serverGraphQL } from '../../utils/helpers/endpoints/endpointUrlBuilder'
 
 export const formatCellText = (
   value: any,
@@ -70,11 +71,23 @@ export const constructElement = (value: any, displayDefinition: DisplayDefinitio
     isRequired: false,
     isReviewable: null,
   }
+
   return (
     <SummaryViewWrapper
       element={element}
-      applicationData={{ config } as ApplicationDetails}
-      /* TODO this is a hacky way of passing through server URL, I think it needs to be decoupled from applicationData. Config is needed for log_url in organisation to be displayed with imageDisplays plugin */
+      // Only "config" info is available in "applicationData", as we're not
+      // using as part of an application. We need server urls, as some plugin
+      // displays (e.g. imageDisplay) require local server urls.
+      applicationData={
+        {
+          config: {
+            serverGraphQL,
+            serverREST,
+            isProductionBuild: config.isProductionBuild,
+            version: config.version,
+          },
+        } as ApplicationDetails
+      }
       response={response}
       allResponses={{}}
     />

--- a/src/formElementPlugins/fileUpload/src/SummaryView.tsx
+++ b/src/formElementPlugins/fileUpload/src/SummaryView.tsx
@@ -5,6 +5,7 @@ import getServerUrl from '../../../utils/helpers/endpoints/endpointUrlBuilder'
 import { SummaryViewProps } from '../../types'
 
 const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, response }) => {
+  console.log('files', response?.files)
   return (
     <Form.Field required={parameters.isRequired}>
       {parameters?.label && (
@@ -19,7 +20,7 @@ const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, respons
             <List.Item key={file.filename} style={{ maxWidth: 150 }}>
               <Grid verticalAlign="top" celled style={{ boxShadow: 'none' }}>
                 <Grid.Row centered style={{ boxShadow: 'none' }} verticalAlign="top">
-                  <a href={getServerUrl('file', file.uniqueId)} target="_blank">
+                  <a href={getServerUrl('file', { fileId: file.uniqueId })} target="_blank">
                     <Image
                       src={getServerUrl('file', { fileId: file.uniqueId, thumbnail: true })}
                       style={{ maxHeight: prefs.summaryViewThumbnailHeight }}

--- a/src/formElementPlugins/fileUpload/src/SummaryView.tsx
+++ b/src/formElementPlugins/fileUpload/src/SummaryView.tsx
@@ -5,7 +5,6 @@ import getServerUrl from '../../../utils/helpers/endpoints/endpointUrlBuilder'
 import { SummaryViewProps } from '../../types'
 
 const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, response }) => {
-  console.log('files', response?.files)
   return (
     <Form.Field required={parameters.isRequired}>
       {parameters?.label && (


### PR DESCRIPTION
Quick fix for the missing logo issue in the Company Data View.

The applicationData that was being passed to the "SummaryView" components in Data Views was incorrect due to a recent change to how the server urls are generated. I'd updated all the other applicationData's, but somehow missed this one.

Have also updated the comment to make it clearer what's going on here.