### PR TITLE
Quick fix: Display checkbox summary even when no response

### DIFF
--- a/src/formElementPlugins/checkbox/src/SummaryView.tsx
+++ b/src/formElementPlugins/checkbox/src/SummaryView.tsx
@@ -35,15 +35,25 @@ const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, respons
       )
       break
     case DisplayFormat.CHECKBOXES:
-      displayComponent = response ? (
+      displayComponent = (
         <CheckboxDisplay
-          checkboxes={getCheckboxStructure(response, checkboxes, keyMap, true)}
+          checkboxes={getCheckboxStructure(
+            response ?? {
+              // If no response exists, we still want to display an empty
+              // checkbox array
+              text: '',
+              values: {},
+            },
+            checkboxes,
+            keyMap,
+            true
+          )}
           disabled
           type={type}
           layout={layout}
           onChange={() => {}}
         />
-      ) : null
+      )
       break
     default:
       displayComponent = <Markdown text={(response ? response.text : '') as string} />


### PR DESCRIPTION
@nmadruga this fixes the problem you were having with checkbox display. Made the SummaryView display the CheckboxDisplay component regardless, and just pass in a "dummy" empty response if no response exists.