### PR TITLE
#946 Don't show invalid review responses in history panel

### DIFF
--- a/src/utils/hooks/useGetQuestionReviewHistory.tsx
+++ b/src/utils/hooks/useGetQuestionReviewHistory.tsx
@@ -50,51 +50,44 @@ const useGetQuestionReviewHistory = ({ isApplicant, ...variables }: UseGetQuesti
 
     applicationResponses.nodes.forEach((applicantResponse) => {
       if (!applicantResponse) return
-      let { stageNumber } = applicantResponse
+      const { stageNumber } = applicantResponse
       const { timeUpdated, application, id, value } = applicantResponse
       const { firstName, lastName } = application?.user as User
 
-      if (!stageNumber) {
-        console.log(`Warning: application_reponse ${id} without any stage_number`)
-        stageNumber = 0
-      }
-
-      if (!allResponsesByStage[stageNumber]) allResponsesByStage[stageNumber] = {}
-
-      // Set each entry using HistoryElement values
-      allResponsesByStage[stageNumber][timeUpdated] = {
-        author: firstName || '' + ' ' + lastName || '',
-        title: strings.TITLE_HISTORY_SUBMITTED_BY_APPLICANT,
-        // TODO translated message, that nothing is entered
-        message: value?.text || '',
-        timeUpdated,
+      if (stageNumber) {
+        if (!allResponsesByStage[stageNumber]) allResponsesByStage[stageNumber] = {}
+        // Set each entry using HistoryElement values
+        allResponsesByStage[stageNumber][timeUpdated] = {
+          author: firstName || '' + ' ' + lastName || '',
+          title: strings.TITLE_HISTORY_SUBMITTED_BY_APPLICANT,
+          // TODO translated message, that nothing is entered
+          message: value?.text || '',
+          timeUpdated,
+        }
       }
     })
 
     reviewResponses.nodes.forEach((reviewResponse) => {
       if (!reviewResponse) return
-      let { stageNumber } = reviewResponse
+      const { stageNumber } = reviewResponse
       const { id, timeUpdated, decision, comment, review } = reviewResponse
       // Avoid breaking app when review is restricted so not returned in query (for Applicant)
       const { levelNumber, reviewer } = review ? review : { levelNumber: 1, reviewer: null }
 
-      if (!stageNumber) {
-        console.log(`Warning: review_reponse ${id} without any stage_number`)
-        stageNumber = 0
-      }
-
-      if (!allResponsesByStage[stageNumber]) allResponsesByStage[stageNumber] = {}
-
       // Set each entry using HistoryElement values
-      allResponsesByStage[stageNumber][timeUpdated] = {
-        author: reviewer ? reviewer?.firstName || '' + ' ' + reviewer?.lastName || '' : '',
-        title:
-          (levelNumber || 1) > 1
-            ? strings.TITLE_HISTORY_CONSOLIDATION
-            : strings.TITLE_HISTORY_REVIEW,
-        message: !!decision ? ReviewResponse[decision] : 'Undefined',
-        timeUpdated,
-        reviewerComment: comment || '',
+      if (stageNumber) {
+        // Exclude *current* review response (which has no stageNumber)
+        if (!allResponsesByStage[stageNumber]) allResponsesByStage[stageNumber] = {}
+        allResponsesByStage[stageNumber][timeUpdated] = {
+          author: reviewer ? reviewer?.firstName || '' + ' ' + reviewer?.lastName || '' : '',
+          title:
+            (levelNumber || 1) > 1
+              ? strings.TITLE_HISTORY_CONSOLIDATION
+              : strings.TITLE_HISTORY_REVIEW,
+          message: !!decision ? ReviewResponse[decision] : 'Undefined',
+          timeUpdated,
+          reviewerComment: comment || '',
+        }
       }
     })
 


### PR DESCRIPTION
Fix #946 

I think this is all it needs. There was existing code that caught responses with no stageNumber defined, and set `stageNumber = 0`. The problem was, the *current* review response (i.e. the one just created for this new review) doesn't have a stage number yet, so we can just exclude these ones and get the correct history display.

I don't actually like how the new review responses don't get a stageNumber set until the review is responded to -- it should really be included in the "createReview" mutation. But it provides a convenient way for us to detect which review responses to exclude from the history list, so I guess we can live with it.

@nmadruga -- do you know why we don't set a stageNumber initially? Is it just an oversight, or was there a good reason for it?