### PR TITLE
#1302 Intermittent problem submitting Product Registration

### DIFF
--- a/src/utils/hooks/useSubmitApplication.tsx
+++ b/src/utils/hooks/useSubmitApplication.tsx
@@ -17,6 +17,7 @@ const useSubmitApplication = ({ serialNumber }: UseGetApplicationProps) => {
       return {
         id: latestApplicationResponse.id,
         patch: {
+          // Don't update values, as it can sometimes make the mutation payload too large:
           // value: latestApplicationResponse.value || null,
           status: ApplicationResponseStatus.Submitted,
         },

--- a/src/utils/hooks/useSubmitApplication.tsx
+++ b/src/utils/hooks/useSubmitApplication.tsx
@@ -1,9 +1,5 @@
 import { useState } from 'react'
-import {
-  ApplicationResponseStatus,
-  TemplateElementCategory,
-  useUpdateApplicationMutation,
-} from '../generated/graphql'
+import { ApplicationResponseStatus, useUpdateApplicationMutation } from '../generated/graphql'
 import { FullStructure, UseGetApplicationProps } from '../types'
 
 const useSubmitApplication = ({ serialNumber }: UseGetApplicationProps) => {
@@ -21,7 +17,7 @@ const useSubmitApplication = ({ serialNumber }: UseGetApplicationProps) => {
       return {
         id: latestApplicationResponse.id,
         patch: {
-          value: latestApplicationResponse.value || null,
+          // value: latestApplicationResponse.value || null,
           status: ApplicationResponseStatus.Submitted,
         },
       }


### PR DESCRIPTION
Fix #1302.

Good we caught this now, would have been annoying to track down after release.

Turns out the "application submit" mutation had too big a payload (JSON variable) for Postgraphile. I've increased the body size limit in the back-end ([PR#836](https://github.com/openmsupply/conforma-server/pull/836)), and I've also stopped sending the "value" field of application responses when submitting application. Some of the responses have very large `value` objects (esp listBuilder), and responses should all be updated when they are edited.

I think this is safe -- please let me know if you can think of a reason why it might not be?