### PR TITLE
#1214 - Warning on Discontinued reviews (Unassigned)

### DIFF
--- a/src/components/PageElements/Elements/ConsolidateReviewDecision.tsx
+++ b/src/components/PageElements/Elements/ConsolidateReviewDecision.tsx
@@ -10,6 +10,7 @@ import ViewHistoryButton from '../ViewHistoryButton'
 
 interface ConsolidateReviewDecisionProps {
   elementCode: string
+  canEdit: boolean
   applicationResponse: ApplicationResponse
   summaryViewProps: SummaryViewWrapperProps
   isActiveReviewResponse: boolean
@@ -23,6 +24,7 @@ interface ConsolidateReviewDecisionProps {
 }
 const ConsolidateReviewDecision: React.FC<ConsolidateReviewDecisionProps> = ({
   elementCode,
+  canEdit,
   applicationResponse,
   summaryViewProps,
   isActiveReviewResponse,
@@ -74,7 +76,7 @@ const ConsolidateReviewDecision: React.FC<ConsolidateReviewDecisionProps> = ({
               isConsolidation={true}
               reviewResponse={reviewResponse}
             >
-              {isActiveReviewResponse && isAssigned && (
+              {canEdit && isActiveReviewResponse && isAssigned && (
                 <UpdateIcon onClick={() => setIsActiveEdit(true)} />
               )}
             </ReviewResponseElement>

--- a/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
+++ b/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
@@ -19,6 +19,7 @@ type ReviewType =
 
 interface ReviewApplicantResponseProps {
   elementCode: string
+  canEdit: boolean
   applicationResponse: ApplicationResponse
   summaryViewProps: SummaryViewWrapperProps
   stageNumber: number
@@ -34,6 +35,7 @@ interface ReviewApplicantResponseProps {
 
 const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
   elementCode,
+  canEdit,
   applicationResponse,
   summaryViewProps,
   stageNumber,
@@ -67,7 +69,7 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
     : 'NotReviewable'
 
   const getReviewDecisionOption = () => {
-    if (isActiveReviewResponse && isChangeRequest && !isChanged)
+    if (canEdit && isActiveReviewResponse && isChangeRequest && !isChanged)
       return (
         <ReviewElementTrigger
           title={strings.LABEL_RESPONSE_UPDATE}
@@ -111,7 +113,9 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
                   isConsolidation={false}
                   reviewResponse={reviewResponse}
                 >
-                  {isActiveReviewResponse && <UpdateIcon onClick={() => setIsActiveEdit(true)} />}
+                  {canEdit && isActiveReviewResponse && (
+                    <UpdateIcon onClick={() => setIsActiveEdit(true)} />
+                  )}
                 </ReviewResponseElement>
               )}
               {consolidationReviewResponse && (
@@ -173,7 +177,8 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
                 applicationResponse={applicationResponse}
                 summaryViewProps={summaryViewProps}
               >
-                {!decisionExists &&
+                {canEdit &&
+                  !decisionExists &&
                   (reviewType === 'OptionallyReviewable' ? (
                     // New review for empty application response
                     <AddIcon onClick={() => setIsActiveEdit(true)} />
@@ -191,7 +196,9 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
                   isConsolidation={false}
                   reviewResponse={reviewResponse}
                 >
-                  {isActiveReviewResponse && <UpdateIcon onClick={() => setIsActiveEdit(true)} />}
+                  {canEdit && isActiveReviewResponse && (
+                    <UpdateIcon onClick={() => setIsActiveEdit(true)} />
+                  )}
                 </ReviewResponseElement>
               )}
               {/* Previous review response */}

--- a/src/components/PageElements/PageElements.tsx
+++ b/src/components/PageElements/PageElements.tsx
@@ -225,6 +225,7 @@ const PageElements: React.FC<PageElementProps> = ({
 
               const props = {
                 elementCode: element.code,
+                canEdit,
                 applicationResponse: latestApplicationResponse,
                 reviewResponse: thisReviewLatestResponse,
                 previousReviewResponse: thisReviewPreviousResponse,

--- a/src/containers/Review/ReviewPage.tsx
+++ b/src/containers/Review/ReviewPage.tsx
@@ -76,19 +76,16 @@ const ReviewPage: React.FC<{
   })
 
   useEffect(() => {
-    if (reviewStatus === ReviewStatus.Pending) {
-      console.log('reviewStatus: PENDING')
+    if (reviewStatus === ReviewStatus.Pending)
       showWarningModal({
         title: strings.REVIEW_STATUS_PENDING_TITLE,
         message: strings.REVIEW_STATUS_PENDING_MESSAGE,
       })
-    } else if (reviewStatus === ReviewStatus.Discontinued) {
-      console.log('reviewStatus: DISCONTINUED')
+    else if (reviewStatus === ReviewStatus.Discontinued)
       showWarningModal({
         title: strings.REVIEW_STATUS_DISCONTINUED_TITLE,
         message: strings.REVIEW_STATUS_DISCONTINUED_MESSAGE,
       })
-    }
   }, [reviewStructure])
 
   if (error) return <Message error title={strings.ERROR_GENERIC} list={[error]} />
@@ -100,10 +97,7 @@ const ReviewPage: React.FC<{
     reviewStructure?.thisReview?.current.reviewStatus !== ReviewStatus.Discontinued
   ) {
     const {
-      info: {
-        name,
-        current: { stage },
-      },
+      info: { name },
     } = reviewStructure
 
     return (

--- a/src/containers/Review/ReviewPage.tsx
+++ b/src/containers/Review/ReviewPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { Button, Header, Icon, Label, Message, Segment } from 'semantic-ui-react'
 import {
   Loading,
@@ -52,7 +52,6 @@ const ReviewPage: React.FC<{
   const {
     userState: { currentUser },
   } = useUserState()
-  const [reviewStatus, setReviewStatus] = useState(ReviewStatus.Submitted)
 
   const { push } = useRouter()
 
@@ -60,6 +59,8 @@ const ReviewPage: React.FC<{
     reviewAssignment,
     reviewStructure: fullApplicationStructure,
   })
+
+  const reviewStatus = reviewStructure?.thisReview?.current.reviewStatus ?? ReviewStatus.Submitted
 
   const { isSectionActive, toggleSection } = useQuerySectionActivation({
     defaultActiveSectionCodes: [],
@@ -75,11 +76,6 @@ const ReviewPage: React.FC<{
   })
 
   useEffect(() => {
-    if (reviewStructure?.thisReview?.current.reviewStatus) {
-      console.log(reviewStructure.thisReview.current.reviewStatus)
-      setReviewStatus(reviewStructure.thisReview.current.reviewStatus)
-    }
-
     if (reviewStatus === ReviewStatus.Pending) {
       console.log('reviewStatus: PENDING')
       showWarningModal({
@@ -93,7 +89,7 @@ const ReviewPage: React.FC<{
         message: strings.REVIEW_STATUS_DISCONTINUED_MESSAGE,
       })
     }
-  }, [reviewStructure, reviewStatus])
+  }, [reviewStructure])
 
   if (error) return <Message error title={strings.ERROR_GENERIC} list={[error]} />
   if (!reviewStructure) return <Loading />

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -335,6 +335,9 @@ export default {
   REVIEW_DECISION_MISMATCH_TITLE: 'Final decision',
   REVIEW_DECISION_MISMATCH_MESSAGE:
     'You have made a different decision than the previous reviewer.\nAre you sure you wish to proceed with your decision?',
+  REVIEW_STATUS_DISCONTINUED_TITLE: 'Review discontinued',
+  REVIEW_STATUS_DISCONTINUED_MESSAGE:
+    'Sorry, this review has been unassigned and cannot be continued.',
   REVIEW_STATUS_PENDING_TITLE: 'Please reload review before submitting',
   REVIEW_STATUS_PENDING_MESSAGE:
     'All your existing decisions will be kept.\nYou will be redirected to the home page now. Click "Start" in there to reload page with latest responses to review.',


### PR DESCRIPTION
Fixes #1214 
Back-end PR: [837](https://github.com/openmsupply/conforma-server/pull/837)

Tests: Please use snapshot `dev/snapshots/Unassignment_warning_test` for testing this. It won't work currently in out angola snapshot since the actions on event ON_REVIEW_ASSIGN and ON_REVIEW_UNASSIGN are not correctly set/missing.

Once you load the `Unassignment_warning_test` snapshot please run `yarn migrate` to get changes on the back-end working.

Then test: 

1. load as `jess` and see the Review of http://localhost:3000/application/S-OSW-0002/review?tab=assignment
2. Open the review page, make changes if desired - but don't submit
3. Open an incognito browser and log in as `nicole` then in http://localhost:3000/application/S-OSW-0002/review?tab=assignment do Un-assignment of jess. 
4. In the other tab looking at the Review page, if you try to add a new review_element, click "Approve all", submit the review or reload it should show the Warning:
![Screen Shot 2022-09-06 at 1 12 50 PM](https://user-images.githubusercontent.com/16461988/188526669-b4fd3e8d-2e83-4253-8c98-af9c29e91b36.png)

No changes can be done - but you see the previous added elements:
![Screen Shot 2022-09-06 at 1 13 08 PM](https://user-images.githubusercontent.com/16461988/188526707-76bfd794-1e51-4142-8693-29559ef62c1e.png)

If this the other user (`nicole`) now Re-assigning back to user `jess`. Then the review should be able to load fine and continued.

### Changes
- Back-end: Fix activity_log functions that caused a problem when running action `ChangeStatus` to set the Review to DISCONTINUED on Un-assignment.
- Updated elements on page to not-editable when the Review status is not DRAFT. Strange that this was allowed before!