### PR TITLE
#849F Delete template "snapshot" after duplicate

### DIFF
--- a/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
+++ b/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
@@ -216,7 +216,7 @@ export const duplicateTemplate: TemplateOperationHelper = async (
 
   if (!result) return false
 
-  return await safeFetch(
+  const snapshotResult = await safeFetch(
     getServerUrl('snapshot', {
       action: 'use',
       name: snapshotName,
@@ -225,6 +225,11 @@ export const duplicateTemplate: TemplateOperationHelper = async (
     body,
     setErrorAndLoadingState
   )
+
+  // Delete the snapshot cos we don't want snapshots page cluttered with individual templates
+  safeFetch(getServerUrl('snapshot', { action: 'delete', name: snapshotName }), {}, () => {})
+
+  return snapshotResult
 }
 
 export const importTemplate: ImportTemplateHelper =


### PR DESCRIPTION
Fix [back-end #848](https://github.com/openmsupply/conforma-server/issues/849) Part 2:

> 2\. when _duplicating_ a template, delete the "snapshot" after import so it doesn't appear in the list (we currently do this from the front-end when _importing_ a template, but needs to happen for duplication too)

Part 1 PR [here](https://github.com/openmsupply/conforma-server/pull/850)