### PR TITLE
Small fix: Text fallback if optionsDisplayProperty is invalid

### DIFF
--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -50,9 +50,12 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     if (!currentResponse?.text && defaultOption !== undefined) {
       const optionIndex = getDefaultIndex(defaultOption, options)
       onSave({
-        text: optionsDisplayProperty
-          ? (options[optionIndex] as ObjectOption)[optionsDisplayProperty]
-          : options[optionIndex],
+        text:
+          optionsDisplayProperty &&
+          options[optionIndex] !== undefined &&
+          typeof options[optionIndex] === 'object'
+            ? (options[optionIndex] as ObjectOption)[optionsDisplayProperty]
+            : options[optionIndex],
         selection: options[optionIndex],
         optionIndex,
         isCustomOption: false,
@@ -90,7 +93,9 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       else
         onSave({
           text:
-            optionsDisplayProperty && options[optionIndex] !== undefined
+            optionsDisplayProperty &&
+            options[optionIndex] !== undefined &&
+            typeof options[optionIndex] === 'object'
               ? (options[optionIndex] as ObjectOption)[optionsDisplayProperty]
               : options[optionIndex],
           selection: options[optionIndex],


### PR DESCRIPTION
This will prevent the problem that occurred due to misconfigured dropDown.

There was an "optionsDisplayProperty" specified, but it wasn't needed as the options query was already returning an array of strings, not an array of objects (as is required for optionsDisplayProperty to work). So it was trying to index a property of a string for its saved text, which resulted in `undefined` (therefore saving `null` to response value).

This change just checks the type of the options value and only tries to find the `optionsDisplayProperty` if it's an object. Otherwise the `optionsDisplayProperty` is quietly ignored.