### PR TITLE
#1346 Update substituteValues in plugins

### DIFF
--- a/src/formElementPlugins/listBuilder/src/displayComponents/ListCardLayout.tsx
+++ b/src/formElementPlugins/listBuilder/src/displayComponents/ListCardLayout.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Card, Icon, Label } from 'semantic-ui-react'
 import { ListLayoutProps } from '../types'
-import { substituteValues } from '../helpers'
+import { substituteValues } from '../../../../utils/helpers/utilityFunctions'
 
 const ListCardLayout: React.FC<ListLayoutProps> = ({
   listItems,

--- a/src/formElementPlugins/listBuilder/src/displayComponents/ListInlineLayout.tsx
+++ b/src/formElementPlugins/listBuilder/src/displayComponents/ListInlineLayout.tsx
@@ -4,7 +4,8 @@ import { ApplicationDetails, ElementState, User } from '../../../../utils/types'
 import { ListItem, ListLayoutProps } from '../types'
 import ApplicationViewWrapper from '../../../ApplicationViewWrapper'
 import SummaryViewWrapper from '../../../SummaryViewWrapper'
-import { buildElements, substituteValues } from '../helpers'
+import { buildElements } from '../helpers'
+import { substituteValues } from '../../../../utils/helpers/utilityFunctions'
 import '../styles.less'
 
 const ListInlineLayout: React.FC<ListLayoutProps> = (props) => {
@@ -52,8 +53,9 @@ const ItemAccordion: React.FC<ItemAccordionProps> = ({
 }) => {
   const [open, setOpen] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
-  const [currentItemElementsState, setItemResponseElementsState] =
-    useState<{ [key: string]: ElementState }>()
+  const [currentItemElementsState, setItemResponseElementsState] = useState<{
+    [key: string]: ElementState
+  }>()
 
   const editItemInline = () => {
     setIsEditing(true)

--- a/src/formElementPlugins/listBuilder/src/displayComponents/ListListLayout.tsx
+++ b/src/formElementPlugins/listBuilder/src/displayComponents/ListListLayout.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Icon, List, ListItem } from 'semantic-ui-react'
 import { ListLayoutProps } from '../types'
-import { substituteValues } from '../helpers'
+import { substituteValues } from '../../../../utils/helpers/utilityFunctions'
 
 const ListCardLayout: React.FC<ListLayoutProps> = ({
   listItems,

--- a/src/formElementPlugins/listBuilder/src/helpers.ts
+++ b/src/formElementPlugins/listBuilder/src/helpers.ts
@@ -19,12 +19,6 @@ export const getDefaultDisplayFormat = (inputFields: TemplateElement[]) => {
   return { title: '', subtitle: '', description: displayString }
 }
 
-export const substituteValues = (parameterisedString: string, item: ListItem) => {
-  const getValueFromCode = (_: string, $: string, code: string) => item[code]?.value?.text || ''
-  // Replaces ${ } formatted substitutions with their values
-  return parameterisedString.replace(/(\${)(.*?)(})/gm, getValueFromCode)
-}
-
 export const createTextString = (listItems: ListItem[], inputFields: TemplateElement[]) =>
   listItems.reduce(
     (outputAcc, item) =>

--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -5,6 +5,7 @@ import { Search, Label, Card, Icon, Form, List, ListItem } from 'semantic-ui-rea
 import { ApplicationViewProps } from '../../types'
 import { useUserState } from '../../../contexts/UserState'
 import { useLanguageProvider } from '../../../contexts/Localisation'
+import { substituteValues } from '../../../utils/helpers/utilityFunctions'
 import evaluateExpression from '@openmsupply/expression-evaluator'
 import config from '../../../config'
 import useDebounce from './useDebounce'
@@ -194,12 +195,6 @@ const getTextFormat = (textFormat: string, selection: any[]): string | undefined
     return `{${itemFields.join(', ')}}`
   })
   return strings.join(', ')
-}
-
-const substituteValues = (parameterisedString: string, object: { [key: string]: any }) => {
-  // TO-DO: Get "nested" object prop (e.g. "user.name"), and display arrays nicely
-  const getValueFromObject = (_: string, $: string, property: string) => object?.[property] || ''
-  return parameterisedString.replace(/(\${)(.*?)(})/gm, getValueFromObject)
 }
 export interface DisplayProps {
   selection: any[]


### PR DESCRIPTION
Fix #1346 

Removes the plugin-specific "substituteValues" functions and replaces them with the generic one from utils. It does exactly the same thing, except the generic one is recursive, so it can handle nested object paths.

Noticed this when I wanted the `displayFormat` value to include `genericNames.text`, but it wouldn't work cos it didn't drill down through the object path.

Generic one does the trick (and should have been done a while ago).

Required for the "displayFormat" of the Product card in "Cancel Product" to display correctly.