### PR TITLE
#31T - Adding new optional locale to getFormattedDate function

### DIFF
--- a/src/containers/TemplateBuilder/evaluatorGui/evaluatorFunctions.ts
+++ b/src/containers/TemplateBuilder/evaluatorGui/evaluatorFunctions.ts
@@ -11,15 +11,26 @@ const generateExpiry = (duration: Duration) => DateTime.now().plus(duration).toJ
 const getYear = (type?: 'short'): string =>
   type === 'short' ? String(new Date().getFullYear()).slice(2) : String(new Date().getFullYear())
 
+type FormatDate =
+  | string
+  | {
+      format: string
+      locale: string
+    }
+
 // Returns ISO date string or JS Date as formatted Date (Luxon). Returns current
 // date if date not supplied
-const getFormattedDate = (formatString: string, date?: string | Date) =>
-  (date
+const getFormattedDate = (formatString: FormatDate, date?: string | Date) => {
+  const tempDate = date
     ? typeof date === 'string'
       ? DateTime.fromISO(date)
       : DateTime.fromJSDate(date)
     : DateTime.now()
-  ).toFormat(formatString)
+
+  if (typeof formatString === 'string') return tempDate.toFormat(formatString)
+  const { format, locale } = formatString
+  return tempDate.setLocale(locale).toFormat(format)
+}
 
 // Returns JS Date object from ISO date string. Returns current timestamp if
 // no parameter supplied

--- a/src/containers/TemplateBuilder/evaluatorGui/evaluatorFunctions.ts
+++ b/src/containers/TemplateBuilder/evaluatorGui/evaluatorFunctions.ts
@@ -11,26 +11,25 @@ const generateExpiry = (duration: Duration) => DateTime.now().plus(duration).toJ
 const getYear = (type?: 'short'): string =>
   type === 'short' ? String(new Date().getFullYear()).slice(2) : String(new Date().getFullYear())
 
-type FormatDate =
+  type FormatDate =
   | string
   | {
       format: string
-      locale: string
+      locale?: string
     }
 
 // Returns ISO date string or JS Date as formatted Date (Luxon). Returns current
 // date if date not supplied
-const getFormattedDate = (formatString: FormatDate, date?: string | Date) => {
-  const tempDate = date
-    ? typeof date === 'string'
-      ? DateTime.fromISO(date)
-      : DateTime.fromJSDate(date)
+const getFormattedDate = (formatString: FormatDate, inputDate?: string | Date) => {
+  const date = inputDate
+    ? typeof inputDate === 'string'
+      ? DateTime.fromISO(inputDate)
+      : DateTime.fromJSDate(inputDate)
     : DateTime.now()
 
-  if (typeof formatString === 'string') return tempDate.toFormat(formatString)
+  if (typeof formatString === 'string') return date.toFormat(formatString)
   const { format, locale } = formatString
-  return tempDate.setLocale(locale).toFormat(format)
-}
+  return date.toFormat(format, { locale })
 
 // Returns JS Date object from ISO date string. Returns current timestamp if
 // no parameter supplied


### PR DESCRIPTION
Added in Conforma-templates issues list since was made for country-specific requirement:
Fixes https://github.com/openmsupply/conforma-templates/issues/31

Back-end PR: https://github.com/openmsupply/conforma-server/pull/858
🔝 Basically same changes - required to get the Action working (Preview & Sending email)

Testing: Please load snapshot (on Conforma-templates repo): `dev/snapshots/Formatted_dates_in_email`
Use user `jess` to preview emails for decision: "Non Conform" or "List of Questions" for review in progress.
Use user `nicole` to preview email for decision "Conform"

Details:

### Kept existing logic for when received only a "string" for formatted date.
  - Check this using Preview of "Non conform" as configured in the SendEmail action:
<img width="730" alt="Screen Shot 2022-09-16 at 12 02 21 PM" src="https://user-images.githubusercontent.com/16461988/190531813-f1402c34-d627-46a1-8f03-cba0246390ee.png">
<img width="587" alt="Screen Shot 2022-09-16 at 11 57 37 AM" src="https://user-images.githubusercontent.com/16461988/190531821-432b6499-be89-408a-a7d0-b08a43f77a5a.png">

### Added new option to pass Object with "format" and "locale" to the function
  - Check this using Preview of "List of Questions" and config in the SendEmail action:
<img width="743" alt="Screen Shot 2022-09-16 at 12 02 40 PM" src="https://user-images.githubusercontent.com/16461988/190531982-bada4a3c-6792-4135-9b84-15a6e6f91707.png">
<img width="588" alt="Screen Shot 2022-09-16 at 12 26 10 PM" src="https://user-images.githubusercontent.com/16461988/190531978-68a31109-5ad7-4429-a97c-c6d482bbd9d6.png">

### Tested that passing the 'Wrong' locale still show some date
  - Check this using Preview of "Conform" and config in SendEmail action:
<img width="589" alt="Screen Shot 2022-09-16 at 12 26 32 PM" src="https://user-images.githubusercontent.com/16461988/190532092-2ceb9455-bfaf-44f2-9607-c909a134f177.png">
<img width="668" alt="Screen Shot 2022-09-16 at 12 03 08 PM" src="https://user-images.githubusercontent.com/16461988/190532097-b73faef8-5b26-49ff-8190-be2bfb3d1ee8.png">
