### PR TITLE
#1351 - Hide option to edit/add reviews on elements in re-assigned sections

### DIFF
--- a/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
+++ b/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
@@ -190,17 +190,24 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
                   ))}
               </ApplicantResponseElement>
               {/* Current review response */}
-              {decisionExists && (
-                <ReviewResponseElement
-                  isCurrentReview={true}
-                  isConsolidation={false}
-                  reviewResponse={reviewResponse}
-                >
-                  {canEdit && isActiveReviewResponse && (
-                    <UpdateIcon onClick={() => setIsActiveEdit(true)} />
+              {isActiveReviewResponse
+                ? canEdit &&
+                  decisionExists && (
+                    <ReviewResponseElement
+                      isCurrentReview={true}
+                      isConsolidation={false}
+                      reviewResponse={reviewResponse}
+                    >
+                      {canEdit && <UpdateIcon onClick={() => setIsActiveEdit(true)} />}
+                    </ReviewResponseElement>
+                  )
+                : decisionExists && (
+                    <ReviewResponseElement
+                      isCurrentReview={true}
+                      isConsolidation={false}
+                      reviewResponse={reviewResponse}
+                    />
                   )}
-                </ReviewResponseElement>
-              )}
               {/* Previous review response */}
               {isNewApplicationResponse && !decisionExists && (
                 <ReviewResponseElement

--- a/src/containers/Review/ReviewPage.tsx
+++ b/src/containers/Review/ReviewPage.tsx
@@ -138,6 +138,11 @@ const ReviewPage: React.FC<{
     thisReview?.current.reviewStatus == ReviewStatus.Locked ||
     thisReview?.current.reviewStatus === ReviewStatus.Discontinued
 
+  const canEdit = (sectionCode: string) =>
+    reviewAssignment?.assignedSections.includes(sectionCode) &&
+    (reviewAssignment?.review?.current.reviewStatus === ReviewStatus.Draft ||
+      reviewAssignment?.review?.current.reviewStatus === ReviewStatus.Locked)
+
   const ReviewSubheader: React.FC = () =>
     isLocked ? (
       <ReviewLockedLabel
@@ -187,7 +192,7 @@ const ReviewPage: React.FC<{
                 </div>
               )}
               extraPageContent={(page: Page) =>
-                reviewStatus === ReviewStatus.Draft && (
+                canEdit(section.details.code) && (
                   <ApproveAllButton
                     isConsolidation={!!section.assignment?.isConsolidation}
                     stageNumber={stage.number}
@@ -207,10 +212,7 @@ const ReviewPage: React.FC<{
               serial={serial}
               reviewInfo={thisReview}
               isConsolidation={section.assignment?.isConsolidation}
-              canEdit={
-                reviewAssignment?.review?.current.reviewStatus === ReviewStatus.Draft ||
-                reviewAssignment?.review?.current.reviewStatus === ReviewStatus.Locked
-              }
+              canEdit={canEdit(section.details.code)}
             />
           ))}
         <PreviousStageDecision


### PR DESCRIPTION
Fixes #1351 

We already have the logic in place to only consider elements reviewed that are in assigned sections to determinate the overall decision. So, the only change required was to hide the option to edit elements that aren't part of the assigned sections...

### Example
1. The reviewer `Nicole Madruga` had all sections assigned, and started to review Section 1:
#### Overview of sections assigned
![Screen Shot 2022-09-19 at 12 59 11 PM](https://user-images.githubusercontent.com/16461988/190935942-22c1e3b5-6087-422e-89a0-a2e94d00aff1.png)

#### Detailed Section 1 in progress
![Screen Shot 2022-09-19 at 12 59 24 PM](https://user-images.githubusercontent.com/16461988/190935946-79ab473b-e813-402e-a139-b046550e56f0.png)

2. Now review `Nicole Madruga` has been un-assigned from Section 1:
#### Overview of sections assigned
![Screen Shot 2022-09-19 at 1 00 12 PM](https://user-images.githubusercontent.com/16461988/190936005-b6302249-35ad-45c3-ae34-b9744692bdb9.png)

#### Detailed Section 1 - Un-assigned
PS: The user can still see their previous reviews, not sure if I should hide this too...
![Screen Shot 2022-09-19 at 12 59 59 PM](https://user-images.githubusercontent.com/16461988/190936031-73d6a00b-2639-43c1-a786-dc5b8b91026b.png)

### Overview of sections after Section 2 & 3 are completed
Reviewer can submit after finishing the assigned work (previous logic)
![Screen Shot 2022-09-19 at 1 00 39 PM](https://user-images.githubusercontent.com/16461988/190936052-2ef599c3-804e-4193-b98e-f938aaa1deaf.png)