### PR TITLE
Tweak for dates in correct format (using Locale from localisation file)

### DIFF
--- a/src/components/List/Cells/DeadlineCell.tsx
+++ b/src/components/List/Cells/DeadlineCell.tsx
@@ -1,17 +1,25 @@
 import React from 'react'
 import { CellProps } from '../../../utils/types'
 import { DateTime } from 'luxon'
+import { useLanguageProvider } from '../../../contexts/Localisation'
 
 // Show date-time in a different colour (red) if deadline is less than this many
 // days away:
 const ALERT_FORMAT_DAYS = 2
 
 const DeadlineCell: React.FC<CellProps> = ({ application }) => {
+  const {
+    selectedLanguage: { locale },
+  } = useLanguageProvider()
   if (!application.applicantDeadline) return null
 
   const deadline = DateTime.fromISO(application.applicantDeadline)
   const textColorClass =
     deadline.diff(DateTime.now(), 'days').days < ALERT_FORMAT_DAYS ? 'alert-colour' : ''
-  return <p className={`slightly-smaller-text ${textColorClass}`}>{deadline.toLocaleString()}</p>
+  return (
+    <p className={`slightly-smaller-text ${textColorClass}`}>
+      {deadline.setLocale(locale).toLocaleString()}
+    </p>
+  )
 }
 export default DeadlineCell

--- a/src/containers/Review/notes/NotesTab.tsx
+++ b/src/containers/Review/notes/NotesTab.tsx
@@ -44,7 +44,10 @@ const NotesTab: React.FC<{
   state: NotesState
   setState: (state: NotesState) => void
 }> = ({ structure: fullStructure, state, setState }) => {
-  const { strings } = useLanguageProvider()
+  const {
+    strings,
+    selectedLanguage: { locale },
+  } = useLanguageProvider()
   const {
     userState: { currentUser },
   } = useUserState()
@@ -132,7 +135,7 @@ const NotesTab: React.FC<{
                   </p>
                   <p className="slightly-smaller-text dark-grey">
                     {DateTime.fromISO(note.timestamp)
-                      .setLocale(strings.LOCALE)
+                      .setLocale(locale)
                       .toLocaleString(DateTime.DATE_FULL)}
                   </p>
                 </div>

--- a/src/containers/Review/notes/NotesTab.tsx
+++ b/src/containers/Review/notes/NotesTab.tsx
@@ -131,7 +131,9 @@ const NotesTab: React.FC<{
                     <strong>{note.user?.fullName}</strong>
                   </p>
                   <p className="slightly-smaller-text dark-grey">
-                    {DateTime.fromISO(note.timestamp).toLocaleString(DateTime.DATETIME_MED)}
+                    {DateTime.fromISO(note.timestamp)
+                      .setLocale(strings.LOCALE)
+                      .toLocaleString(DateTime.DATE_FULL)}
                   </p>
                 </div>
               </div>

--- a/src/contexts/Localisation.tsx
+++ b/src/contexts/Localisation.tsx
@@ -14,6 +14,7 @@ const initSelectedLanguage: LanguageOption = {
   languageName: '',
   description: '',
   flag: '',
+  locale: 'en_GB',
   enabled: true,
 }
 
@@ -28,6 +29,7 @@ export type LanguageOption = {
   languageName: string
   description: string
   code: string
+  locale: string
   flag: string // To-do: limit to flag emojis
   enabled: boolean
 }

--- a/src/contexts/Localisation.tsx
+++ b/src/contexts/Localisation.tsx
@@ -14,7 +14,7 @@ const initSelectedLanguage: LanguageOption = {
   languageName: '',
   description: '',
   flag: '',
-  locale: 'en_GB',
+  locale: '',
   enabled: true,
 }
 

--- a/src/formElementPlugins/datePicker/src/ApplicationView.tsx
+++ b/src/formElementPlugins/datePicker/src/ApplicationView.tsx
@@ -3,6 +3,8 @@ import { ApplicationViewProps } from '../../types'
 import SemanticDatepicker from 'react-semantic-ui-datepickers'
 import { DateTime } from 'luxon'
 import 'react-semantic-ui-datepickers/dist/react-semantic-ui-datepickers.css'
+import { useLanguageProvider } from '../../../contexts/Localisation'
+import { LocaleOptions } from 'react-semantic-ui-datepickers/dist/types'
 
 // Stored response date format
 interface DateSaved {
@@ -35,13 +37,15 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const [selectedDate, setSelectedDate] = useState<SelectedDateRange>(
     fromDateSaved(currentResponse?.date)
   )
+  const {
+    selectedLanguage: { locale },
+  } = useLanguageProvider()
   const { isEditable } = element
   const {
     label,
     description,
     default: defaultDate,
     allowRange = Array.isArray(defaultDate),
-    locale = 'en-US',
     displayFormat = 'short',
     entryFormat = 'YYYY-MM-DD',
     minDate,
@@ -87,7 +91,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       )}
       <Markdown text={description} />
       <SemanticDatepicker
-        locale={locale}
+        locale={(locale as LocaleOptions) || 'en-US'}
         onChange={handleSelect}
         type={allowRange ? 'range' : 'basic'}
         value={selectedDate}

--- a/src/formElementPlugins/datePicker/src/ApplicationView.tsx
+++ b/src/formElementPlugins/datePicker/src/ApplicationView.tsx
@@ -37,15 +37,14 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const [selectedDate, setSelectedDate] = useState<SelectedDateRange>(
     fromDateSaved(currentResponse?.date)
   )
-  const {
-    selectedLanguage: { locale },
-  } = useLanguageProvider()
+  const { selectedLanguage } = useLanguageProvider()
   const { isEditable } = element
   const {
     label,
     description,
     default: defaultDate,
     allowRange = Array.isArray(defaultDate),
+    locale = selectedLanguage.locale,
     displayFormat = 'short',
     entryFormat = 'YYYY-MM-DD',
     minDate,
@@ -91,7 +90,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       )}
       <Markdown text={description} />
       <SemanticDatepicker
-        locale={(locale as LocaleOptions) || 'en-US'}
+        locale={locale}
         onChange={handleSelect}
         type={allowRange ? 'range' : 'basic'}
         value={selectedDate}

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -208,6 +208,7 @@ export default {
   LABEL_VERIFICATION_FAILED: 'Verificaton Failed',
   LINK_NEW_ACCOUNT: 'Create new account',
   LINK_RESET_PASSWORD: 'Forgot my password',
+  LOCALE: 'en-GB',
   LOCALISATION_HEADER: 'Localisation',
   LOCALISATION_CURRENTLY_INSTALLED: 'Currently installed languages',
   LOCALISATION_DELETE_WARNING_TITLE: 'Are you sure?',

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -208,7 +208,6 @@ export default {
   LABEL_VERIFICATION_FAILED: 'Verificaton Failed',
   LINK_NEW_ACCOUNT: 'Create new account',
   LINK_RESET_PASSWORD: 'Forgot my password',
-  LOCALE: 'en-GB',
   LOCALISATION_HEADER: 'Localisation',
   LOCALISATION_CURRENTLY_INSTALLED: 'Currently installed languages',
   LOCALISATION_DELETE_WARNING_TITLE: 'Are you sure?',

--- a/src/utils/hooks/useTimeline/eventInterpretation.ts
+++ b/src/utils/hooks/useTimeline/eventInterpretation.ts
@@ -107,7 +107,8 @@ const getOutcomeEvent = ({ value }: ActivityLog, strings: LanguageStrings): Even
 
 const getExtensionEvent = (
   { value, details }: ActivityLog,
-  strings: LanguageStrings
+  strings: LanguageStrings,
+  locale: string
 ): EventOutput => {
   if (value !== config.applicantDeadlineCode)
     return {
@@ -123,7 +124,7 @@ const getExtensionEvent = (
     displayString: `${strings.TIMELINE_DEADLINE_EXTENDED.replace(
       '%1',
       `**${name}**`
-    )} ${DateTime.fromISO(newDeadline).toLocaleString(DateTime.DATETIME_SHORT)}`,
+    )} ${DateTime.fromISO(newDeadline).setLocale(locale).toLocaleString(DateTime.DATETIME_SHORT)}`,
   }
 }
 

--- a/src/utils/hooks/useTimeline/useTimeline.tsx
+++ b/src/utils/hooks/useTimeline/useTimeline.tsx
@@ -172,7 +172,7 @@ const generateTimelineEvent: {
     ({ eventType: TimelineEventType.Ignore, displayString: '' }),
   STATUS: (event, fullLog, _, __, strings) => getStatusEvent(event, fullLog, strings),
   OUTCOME: (event, _, __, ___, strings) => getOutcomeEvent(event, strings),
-  EXTENSION: (event, _, __, ___, strings, _____, locale) =>
+  EXTENSION: (event, _, __, ___, strings, ____, locale) =>
     getExtensionEvent(event, strings, locale),
   ASSIGNMENT: (event, _, structure, __, strings) => getAssignmentEvent(event, structure, strings),
   REVIEW: (event, fullLog, structure, index, strings, decisionStrings) =>

--- a/src/utils/hooks/useTimeline/useTimeline.tsx
+++ b/src/utils/hooks/useTimeline/useTimeline.tsx
@@ -20,7 +20,10 @@ import useLocalisedEnums from '../useLocalisedEnums'
 import { TimelineStage, Timeline, TimelineEventType, EventOutput, TimelineEvent } from './types'
 
 const useTimeline = (structure: FullStructure) => {
-  const { strings } = useLanguageProvider()
+  const {
+    strings,
+    selectedLanguage: { locale },
+  } = useLanguageProvider()
   const { Decision: decisionStrings } = useLocalisedEnums()
   const [timeline, setTimeline] = useState<Timeline>()
   const [error, setError] = useState('')
@@ -46,7 +49,8 @@ const useTimeline = (structure: FullStructure) => {
           data?.activityLogs?.nodes as ActivityLog[],
           structure,
           strings,
-          decisionStrings
+          decisionStrings,
+          locale
         )
       )
       setLoading(false)
@@ -62,7 +66,8 @@ const buildTimeline = (
   activityLog: ActivityLog[],
   structure: FullStructure,
   strings: LanguageStrings,
-  decisionStrings: { [key in Decision]: string }
+  decisionStrings: { [key in Decision]: string },
+  locale: string
 ): Timeline => {
   // Group by stage
   const stages: TimelineStage[] = []
@@ -85,7 +90,8 @@ const buildTimeline = (
           structure,
           index,
           strings,
-          decisionStrings
+          decisionStrings,
+          locale
         ),
         logType: event.type,
       }
@@ -157,7 +163,8 @@ const generateTimelineEvent: {
     strings: LanguageStrings,
     decisionStrings: {
       [key in Decision]: string
-    }
+    },
+    locale: string
   ) => EventOutput
 } = {
   STAGE: () =>
@@ -165,7 +172,8 @@ const generateTimelineEvent: {
     ({ eventType: TimelineEventType.Ignore, displayString: '' }),
   STATUS: (event, fullLog, _, __, strings) => getStatusEvent(event, fullLog, strings),
   OUTCOME: (event, _, __, ___, strings) => getOutcomeEvent(event, strings),
-  EXTENSION: (event, _, __, ___, strings) => getExtensionEvent(event, strings),
+  EXTENSION: (event, _, __, ___, strings, _____, locale) =>
+    getExtensionEvent(event, strings, locale),
   ASSIGNMENT: (event, _, structure, __, strings) => getAssignmentEvent(event, structure, strings),
   REVIEW: (event, fullLog, structure, index, strings, decisionStrings) =>
     getReviewEvent(event, fullLog, structure, index, strings, decisionStrings),

--- a/src/utils/localisation/exportLanguages.ts
+++ b/src/utils/localisation/exportLanguages.ts
@@ -53,6 +53,8 @@ export const exportLanguages = async (
     const row3code = ['Code:', '', ...languageOptions.map((opt) => opt.code)]
     const row4Flag = ['Flag:', '', ...languageOptions.map((opt) => opt.flag)]
     const row5Enabled = ['Enabled?', '', ...languageOptions.map((opt) => opt.enabled)]
+    const row6Locale = ['Locale:', '', ...languageOptions.map((opt) => opt.locale)]
+
     const translationRows = Object.keys(defaultLanguageStrings).map((key) => [
       key,
       ...Object.values(translationsObject[key as keyof LanguageStrings]),
@@ -68,6 +70,7 @@ export const exportLanguages = async (
       row3code,
       row4Flag,
       row5Enabled,
+      row6Locale,
       [],
       ['KEYS'],
       ...translationRows,

--- a/src/utils/localisation/exportLanguages.ts
+++ b/src/utils/localisation/exportLanguages.ts
@@ -52,8 +52,8 @@ export const exportLanguages = async (
     ]
     const row3code = ['Code:', '', ...languageOptions.map((opt) => opt.code)]
     const row4Flag = ['Flag:', '', ...languageOptions.map((opt) => opt.flag)]
-    const row5Enabled = ['Enabled?', '', ...languageOptions.map((opt) => opt.enabled)]
-    const row6Locale = ['Locale:', '', ...languageOptions.map((opt) => opt.locale)]
+    const row5Locale = ['Locale:', '', ...languageOptions.map((opt) => opt.locale)]
+    const row6Enabled = ['Enabled?', '', ...languageOptions.map((opt) => opt.enabled)]
 
     const translationRows = Object.keys(defaultLanguageStrings).map((key) => [
       key,
@@ -69,8 +69,8 @@ export const exportLanguages = async (
       row2Description,
       row3code,
       row4Flag,
-      row5Enabled,
-      row6Locale,
+      row5Locale,
+      row6Enabled,
       [],
       ['KEYS'],
       ...translationRows,

--- a/src/utils/localisation/importLanguages.ts
+++ b/src/utils/localisation/importLanguages.ts
@@ -29,26 +29,31 @@ export const importLanguages = async (
       } as LanguageObject)
   )
 
-  // Row 0 -- Language names
-  rows[0].map((name, index) => (languageObjects[index].languageName = name))
+  let rowIndex = 0
 
-  // Row 1 -- Description
-  rows[1].map((description, index) => (languageObjects[index].description = description))
+  // Row 1 -- Language names
+  rows[rowIndex++].map((name, index) => (languageObjects[index].languageName = name))
 
-  // Row 2 -- Code
-  rows[2].map((code, index) => (languageObjects[index].code = code))
+  // Row 2 -- Description
+  rows[rowIndex++].map((description, index) => (languageObjects[index].description = description))
 
-  // Row 3 -- Flag
-  rows[3].map((flag, index) => (languageObjects[index].flag = flag))
+  // Row 3 -- Code
+  rows[rowIndex++].map((code, index) => (languageObjects[index].code = code))
 
-  // Row 4 -- Enabled
-  rows[4].map(
+  // Row 4 -- Flag
+  rows[rowIndex++].map((flag, index) => (languageObjects[index].flag = flag))
+
+  // Row 5 -- Locale
+  rows[rowIndex++].map((locale, index) => (languageObjects[index].locale = locale))
+
+  // Row 6 -- Enabled
+  rows[rowIndex++].map(
     (enabled, index) =>
       (languageObjects[index].enabled = enabled.toLowerCase() === 'true' ? true : false)
   )
 
-  // Iterate over language rows
-  for (let i = 7; i < rows.length; i++) {
+  // Iterate over language rows - starting on first row after headers parsed
+  for (let i = rowIndex + 1; i < rows.length; i++) {
     const row = rows[i]
     const key = row[0] as keyof LanguageStrings
     if (key === ('' as string)) break // End of strings
@@ -61,8 +66,8 @@ export const importLanguages = async (
   const uploadObjects = languageObjects
     .slice(2) // First two are keys and default strings
     .filter((language) => (importDisabled ? true : language.enabled))
-    .map(({ languageName, description, code, flag, enabled, translations }) => ({
-      language: { languageName, description, code, flag, enabled },
+    .map(({ languageName, description, code, flag, locale, enabled, translations }) => ({
+      language: { languageName, description, code, flag, locale, enabled },
       strings: translations,
     }))
 


### PR DESCRIPTION
Just add locale to our localisation file and use in Notes tab (Review) and Applicant Deadline

Notes tab example (using locale: 'pt'):
![Screen Shot 2022-09-20 at 1 08 24 PM](https://user-images.githubusercontent.com/16461988/191145512-667764d3-9d8b-47d6-bd6b-6b5320b8fd06.png)

Considering... do we need to change this as well?
![Screen Shot 2022-09-20 at 1 07 04 PM](https://user-images.githubusercontent.com/16461988/191145550-06cb7799-0dc4-4bb6-bef2-881b4eef609e.png)
