### PR TITLE
Tweaks in application container

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -455,8 +455,6 @@ a:hover {
 
 #content-area .top-container {
   margin-top: 20px;
-  display: flex;
-  flex-direction: column;
   flex-wrap: wrap;
   justify-content: space-between;
 }

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -454,18 +454,20 @@ a:hover {
 }
 
 #content-area .top-container {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column-reverse;
   flex-wrap: wrap;
   justify-content: space-between;
-  padding-bottom: 20px;
 }
 
 // Back to application list label
 #content-area .back-label {
   min-width: 132px;
-  max-width: 350px;
   background-color: transparent;
   font-size: @fontSmall;
   font-weight: @regularWeight;
+  padding-left: 10%;
 }
 
 // Fix for company header on mobile to not clash with 'back to applications'

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -456,7 +456,7 @@ a:hover {
 #content-area .top-container {
   margin-top: 20px;
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
   flex-wrap: wrap;
   justify-content: space-between;
 }

--- a/src/components/Application/ApplicationContainer.tsx
+++ b/src/components/Application/ApplicationContainer.tsx
@@ -22,13 +22,10 @@ const ApplicationContainer: React.FC<ApplicationContainerProps> = ({ template, c
         <Label
           className="back-label clickable"
           onClick={() => replace(`/applications?type=${code}`)}
-          content={
-            <>
-              <Icon name="chevron left" className="dark-grey" />
-              {`${name} ${strings.LABEL_APPLICATIONS}`}
-            </>
-          }
-        />
+        >
+          <Icon name="chevron left" className="dark-grey" />
+          {strings.LABEL_APPLICATIONS.replace('%1', name)}
+        </Label>
         {currentUser?.organisation?.orgName && (
           <Header
             as="h2"

--- a/src/components/Application/ApplicationContainer.tsx
+++ b/src/components/Application/ApplicationContainer.tsx
@@ -19,13 +19,6 @@ const ApplicationContainer: React.FC<ApplicationContainerProps> = ({ template, c
   return (
     <Container id="application-area" className={isNonRegistered ? 'non-registered' : ''}>
       <div className={`top-container ${isNonRegistered ? 'hidden-element' : ''}`}>
-        <Label
-          className="back-label clickable"
-          onClick={() => replace(`/applications?type=${code}`)}
-        >
-          <Icon name="chevron left" className="dark-grey" />
-          {strings.LABEL_APPLICATIONS.replace('%1', name)}
-        </Label>
         {currentUser?.organisation?.orgName && (
           <Header
             as="h2"
@@ -34,6 +27,13 @@ const ApplicationContainer: React.FC<ApplicationContainerProps> = ({ template, c
             content={currentUser?.organisation?.orgName}
           />
         )}
+        <Label
+          className="back-label clickable"
+          onClick={() => replace(`/applications?type=${code}`)}
+        >
+          <Icon name="chevron left" className="dark-grey" />
+          {strings.LABEL_APPLICATIONS.replace('%1', name)}
+        </Label>
       </div>
       {children}
     </Container>

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -148,7 +148,7 @@ export default {
   FILTER_DATE_BEFORE: 'Before',
   FILTER_DATE_AFTER: 'After',
   FILTER_RESET_ALL: 'Reset all filters',
-  LABEL_APPLICATIONS: 'applications',
+  LABEL_APPLICATIONS: '%1 applications',
   LABEL_APPLICATION_SUBMITTED: 'Application Submitted',
   LABEL_APPLICATION_BACK: 'Back to form',
   LABEL_ASSIGNED_TO_YOU: 'Assigned to you',


### PR DESCRIPTION
Just 2 tweaks on the Application Home page.

1. Changed the string, which wasn't easy to translate in Portuguese
2. Re-ordered the Title (with Company name) and back button
* It has annoyed me for a while. I tried a few things, and re-ordering so the company shows first and the button to see Applications list after seems a little bit better. 

#### Previously
![Screen Shot 2022-09-28 at 12 34 42 PM](https://user-images.githubusercontent.com/16461988/192670910-85d24b2e-becb-41b7-85fb-c4569eacea59.png)
![Screen Shot 2022-09-28 at 12 35 29 PM](https://user-images.githubusercontent.com/16461988/192670920-99b0ffa1-a49d-45b8-8857-07cc1841d877.png)

#### With this PR
![Screen Shot 2022-09-28 at 2 57 51 PM](https://user-images.githubusercontent.com/16461988/192670875-acc162c7-9aad-478f-97ee-06d43a67c8a8.png)
