### PR TITLE
#1361 Application list -- default filters fix

### DIFF
--- a/src/containers/List/ListFilters/ListFilters.tsx
+++ b/src/containers/List/ListFilters/ListFilters.tsx
@@ -39,13 +39,15 @@ const ListFilters: React.FC<{
   const defaultDisplayFilters = getDefaultDisplayFilters(filterDefinitions)
 
   const filterNames = Object.keys(displayableFilters)
-  const [activeFilters, setActiveFilters] = useState<string[]>(defaultDisplayFilters)
+  const [activeFilters, setActiveFilters] = useState<string[]>([])
 
   // Add filters from URL to activeFilters, filters may not have criteria/options yet thus we have to use activeFilter state variable
   useEffect(() => {
     const filtersInQuery = filterNames.filter((filterName) => !!query[filterName])
     const newFilters = filtersInQuery.filter((filterName) => !activeFilters.includes(filterName))
-    setActiveFilters([...activeFilters, ...newFilters])
+    if (activeFilters.length === 0 && newFilters.length === 0)
+      setActiveFilters(defaultDisplayFilters)
+    else setActiveFilters([...activeFilters, ...newFilters])
   }, [query])
 
   // Filter criteria/options states is provided by query URL, methods below are get and set query fiter criteria

--- a/src/utils/helpers/list/useGetFilterDefinitions.ts
+++ b/src/utils/helpers/list/useGetFilterDefinitions.ts
@@ -22,7 +22,12 @@ export const useGetFilterDefinitions = () => {
 
   const { preferences } = usePrefs()
 
-  const defaultFilters = preferences?.defaultListFilters || []
+  const defaultFilters = preferences?.defaultListFilters || [
+    'applicantDeadline',
+    'reviewers',
+    'reviewerAction',
+    'stage',
+  ]
 
   const NAMED_DATE_RANGES: NamedDates = {
     today: { getDates: () => [today(), today()], title: strings.FILTER_NAMED_DATE_TODAY },


### PR DESCRIPTION
Fix #1361 

The problem was, when going to the page from the dashboard, the "defaultDisplayFilters" was empty, because the `userRole` had not yet been defined from the query, but we initialised `activeFilters` with this anyway. 

And then when the query updated, the active filters got over-written with `[...activeFilters, ...newFilters]`, which was also empty. And even though`defaultDisplayFilters` was updated, the state of `activeFilters` didn't change, since it was only the initialised value that depended on it.

This change just moves consideration of `defaultDisplayFilters` into the `useEffect` that happens when the query changes -- and if there are no filters already active or defined in the query, it'll use the default ones.

This also means that if you load a page with a filter already defined in the url, you'll only get those filters activated, not the default ones. I assume this is okay? I think it makes sense, but feel free to disagree.

---

I've also added defaults for when the "defaultFilters" is not defined in prefs. We should always have defaults for things like this, preferences should just be for when we want it to be different to the default.