### PR TITLE
#1365 Fix missing label on Search Summary view

### DIFF
--- a/src/formElementPlugins/search/src/SummaryView.tsx
+++ b/src/formElementPlugins/search/src/SummaryView.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
+import { Form } from 'semantic-ui-react'
 import { SummaryViewProps } from '../../types'
 import { DisplaySelection, DisplayProps } from './ApplicationView'
 
 const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, response }) => {
-  const { displayFormat, displayType = 'card' } = parameters
+  const { label, displayFormat, displayType = 'card' } = parameters
 
   const displayProps: DisplayProps = {
     selection: response?.selection ?? [],
@@ -13,7 +14,16 @@ const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, respons
     isEditable: false,
   }
 
-  return <DisplaySelection {...displayProps} />
+  return (
+    <Form.Field>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
+      <DisplaySelection {...displayProps} />
+    </Form.Field>
+  )
 }
 
 export default SummaryView


### PR DESCRIPTION
Fix #1365.

Not sure how long this has been like this, maybe forever? 🤷‍♂️

Anyway, I've just put the same Form and Label wrapper in the Summary View so it's consistent with all the other Summary View components.