### PR TITLE
#1232 Fix Applicant summary page re-direct loop

### DIFF
--- a/src/containers/Application/ApplicationSummary.tsx
+++ b/src/containers/Application/ApplicationSummary.tsx
@@ -45,7 +45,9 @@ const ApplicationSummary: React.FC<ApplicationProps> = ({
     if (fullStructure.info.current.status === ApplicationStatus.ChangesRequired)
       replace(`/application/${fullStructure.info.serial}`)
 
-    // Don't check further if completed, otherwise gets into re-direct loop
+    // This shouldn't be needed, but just for extra defence -- if the validity
+    // check below is allowed to proceed on completed applications, it gets into
+    // an infinite re-direct loop
     if (fullStructure.info.current.status === ApplicationStatus.Completed) return
 
     // Re-direct if application is not valid

--- a/src/containers/Application/ApplicationSummary.tsx
+++ b/src/containers/Application/ApplicationSummary.tsx
@@ -45,6 +45,9 @@ const ApplicationSummary: React.FC<ApplicationProps> = ({
     if (fullStructure.info.current.status === ApplicationStatus.ChangesRequired)
       replace(`/application/${fullStructure.info.serial}`)
 
+    // Don't check further if completed, otherwise gets into re-direct loop
+    if (fullStructure.info.current.status === ApplicationStatus.Completed) return
+
     // Re-direct if application is not valid
     if (fullStructure.info.firstStrictInvalidPage) {
       const { sectionCode, pageNumber } = fullStructure.info.firstStrictInvalidPage

--- a/src/utils/hooks/useGetApplicationStructure.tsx
+++ b/src/utils/hooks/useGetApplicationStructure.tsx
@@ -32,7 +32,7 @@ const useGetApplicationStructure = ({
   shouldRevalidate = false,
   minRefetchTimestampForRevalidation = 0,
   firstRunValidation = true,
-  shouldCalculateProgress = true,
+  shouldCalculateProgress = structure.info.current.status !== ApplicationStatus.Completed,
   shouldGetDraftResponses = true,
   forceRun = false,
 }: UseGetApplicationStructureProps) => {


### PR DESCRIPTION
Fix #1232 

Finally got to the bottom of this one. 

If you haven't seen the problem, I'm pretty sure you can re-create it by looking at a completed application as the applicant.

The problem was the application progress was being recalculated, even for completed applications, which was causing the validity check to fail on the summary page, and redirect back to an application page, etc.

I've kind of done a "double-fix" here. Either one on its own should fix the immediate problem, but setting the "shouldCalculateProgress" default based on the current status is more "correct", I think. 

The other fix is purely defensive -- we don't really need it if the first fix is working properly, but I thought it can't hurt to leave it in just in case (and since the result is so unpleasant if it fails)