### PR TITLE
#1381 Fix when changing application list page

### DIFF
--- a/src/containers/List/ListFilters/ListFilters.tsx
+++ b/src/containers/List/ListFilters/ListFilters.tsx
@@ -109,7 +109,7 @@ const ListFilters: React.FC<{
       </Dropdown>
       {activeFilters.map((filterName) => {
         const filter = displayableFilters[filterName]
-        if (!filter.title) return null
+        if (!filter?.title) return null
 
         switch (filter.type) {
           case 'enumList':


### PR DESCRIPTION
Fix #1381 

Smallest PR ever?

Basically just handles the case when the `filter` in `displayableFilters` is not found, which is the case on the first render after changing list page.