### PR TITLE
892B improve filters in dashboard with single query for each panel

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -1648,12 +1648,10 @@ a:hover {
       }
 
       .filters {
-        .flex-column();
         flex-grow: 1;
       }
 
       .filter {
-        display: flex;
         align-items: center;
       }
     }

--- a/src/utils/graphql/queries/getApplicationsList.query.ts
+++ b/src/utils/graphql/queries/getApplicationsList.query.ts
@@ -4,8 +4,8 @@ export default gql`
   query getApplicationList(
     $filters: ApplicationListShapeFilter
     $sortFields: [ApplicationListShapesOrderBy!]
-    $paginationOffset: Int!
-    $numberToFetch: Int!
+    $paginationOffset: Int
+    $numberToFetch: Int
     $userId: Int! = 0
     $templateCode: String!
   ) {

--- a/src/utils/helpers/list/buildQueryVariables.ts
+++ b/src/utils/helpers/list/buildQueryVariables.ts
@@ -30,10 +30,13 @@ const mapSortFields: any = {
 // ----
 
 interface PaginationValues {
-  numberToFetch: number
-  paginationOffset: number
+  numberToFetch?: number
+  paginationOffset?: number
 }
 
-export function getPaginationVariables(page: number, perPage = 20): PaginationValues {
-  return { numberToFetch: perPage, paginationOffset: (page - 1) * perPage }
+export function getPaginationVariables(
+  page: number,
+  perPage: number | undefined
+): PaginationValues {
+  return { numberToFetch: perPage, paginationOffset: perPage ? (page - 1) * perPage : undefined }
 }

--- a/src/utils/helpers/utilityFunctions.ts
+++ b/src/utils/helpers/utilityFunctions.ts
@@ -51,3 +51,15 @@ export const replaceCommas = (value: string) => value.replace(new RegExp(MAGIC_S
 
 export const removeCommasArray = (values: string[]) => values.map((value) => removeCommas(value))
 export const replaceCommasArray = (values: string[]) => values.map((value) => replaceCommas(value))
+
+// Constructs OR filter for an objects-array i.e. [ {fieldName1: value1}, {fieldName1: value2} ]
+// Returns the GraphQL filter i.e: { or: {fieldName1: { equalsTo: value1 }}, {fieldName1: { equalsTo: value2} }}}
+// This is useful to filter same key with many values using OR statement
+export const constructOrObjectFilters = (filters: { [key: string]: string }[]) => ({
+  or: Object.values(filters).map((filter) => {
+    // Each filter is currently delimited to a single check!
+    const filterKey = Object.keys(filter)[0]
+    const filterValue = Object.values(filter)[0]
+    return { [filterKey]: { equalTo: filterValue } }
+  }),
+})

--- a/src/utils/hooks/useListApplications.tsx
+++ b/src/utils/hooks/useListApplications.tsx
@@ -7,13 +7,10 @@ import { BasicStringObject, TemplateType } from '../types'
 import { useUserState } from '../../contexts/UserState'
 import { useGetFilterDefinitions } from '../helpers/list/useGetFilterDefinitions'
 
-const useListApplications = ({
-  sortBy,
-  page,
-  perPage,
-  type,
-  ...queryFilters
-}: BasicStringObject) => {
+const useListApplications = (
+  { sortBy, page, perPage, type, ...queryFilters }: BasicStringObject,
+  queryMultiFilters?: object
+) => {
   const FILTER_DEFINITIONS = useGetFilterDefinitions()
   const [applications, setApplications] = useState<ApplicationListShape[]>([])
   const [applicationCount, setApplicationCount] = useState<number>(0)
@@ -24,7 +21,12 @@ const useListApplications = ({
     userState: { currentUser },
   } = useUserState()
 
-  const filters = buildFilter({ type, ...queryFilters }, FILTER_DEFINITIONS)
+  // If queryMultiFilters is passed it will be considering only that
+  // for filtering the list of applications - otherwise will have to
+  // buildFilters parsing to GraphQL what is passed on the URL
+  const filters = queryMultiFilters
+    ? queryMultiFilters
+    : buildFilter({ type, ...queryFilters }, FILTER_DEFINITIONS)
   const sortFields = sortBy ? buildSortFields(sortBy) : []
   const { paginationOffset, numberToFetch } = getPaginationVariables(
     page ? Number(page) : 1,


### PR DESCRIPTION
Take 3 🎬 
Based from #1363 

### Changes
1. This will attempt to help with the delay to load Dashboard page. As noticed by Carl, each single filter would be calling `getApplicationList` each time in order to retrieve each on those account for the applications related to actions. This PR changes that to be one call to getApplicationList per Panel (template). 
2. Also noticed we use pagination was not correctly set, and had the list of applications up to 20. Now changed to be checking the full list (by not passing any pagination parameter)
3. It was required to add a new function to parse into GraphQL query considering an OR statement for each type of filter discovered in the Filters configured for this Dashboard, which was different from what is currently done by `buildFilters` in useApplicationsList. So, the best approach - as discussed with Carl was to parse this property `queryMultiFilter` separetelly and pass on to be called straight to one GraphQL call by the `useApplicationList` hook.

### Explanation about 3rd PR on a roll

I couldn't see the problem - When testing locally with latest build (0.4.6-5) + snapshot it seems fine and I can use filters... So I'm not sure what is the problem. But in case I missed something - And when I compared there are some conflict resolutions on buildQueryFilters so maybe that's where you saw a problem. That's the reason for creating this 3rd version of the orginal.

### Replying to previous comment
> start from a fresh 1363-data-view-filters----extra-issues base and just paste in the changes in a new branch

Done

> I don't think we need the pagination changes any more. I think the filter construction you've added is enough to do what we want, and making the pagination variables optional is just adding unnecessary complexity that we don't actually need. Was a bit of a red herring I think, apologies if I sent you in the wrong direction.

It is required otherwise it would be using the default 20 - Checkout the change from:
https://github.com/openmsupply/conforma-web-app/blob/49ef9e54243ae1594b86b8864d73d352b841aec4/src/utils/helpers/list/buildQueryVariables.ts#L37-L39

> I don't think there's any rush to get this in to the stable branch. It's definitely useful, but I don't think it's mission-critical, as the indexing is helping a lot with loading times now. So we can probably park this until early next week if you like and then we can merge a simplified version once the filtering stuff is all in place. I'm just thinking of time -- if you're concerned about getting a stable release for this week, then you might not want to spend more time trying to figure this out right now, and we can live without it till next week. But currently it's breaking too many other things. Hopefully reverting that pagination change helps, but I can't know for sure without a closer inspection.

I would prefer to get this in. There is no point of keeping things out from develop if this is going to be tested on our test instances. It has been reviewed, so the problem that I can see here is only related to trying to get other branches in queue. I'm terrible sorry about a bad conflict resolution - this is all my fault. But I keep saying we need to use more of `develop` to test and keep moving forward. Otherwise it will give problems like this. I agree we should have kept this in a separate feature branch, but I have been pushing to get this on develop because it will help when deploying the newly reviewed branches. Now that we have added this to the angola instance, it would definitely be time to merge in - so we can release things more safely after all combined.