### PR TITLE
Fix incorrect decision on review submit

### DIFF
--- a/src/containers/Review/ReviewSubmit.tsx
+++ b/src/containers/Review/ReviewSubmit.tsx
@@ -122,9 +122,7 @@ const ReviewSubmitButton: React.FC<ReviewSubmitProps & ReviewSubmitButtonProps> 
     reviewAssignment: assignment,
   })
 
-  const { ConfirmModal, showModal: showConfirmModal } = useConfirmationModal({
-    onConfirm: () => submission(),
-  })
+  const { ConfirmModal, showModal: showConfirmModal } = useConfirmationModal()
   const { ConfirmModal: WarningModal, showModal: showWarning } = useConfirmationModal({
     type: 'warning',
   })
@@ -201,7 +199,7 @@ const ReviewSubmitButton: React.FC<ReviewSubmitProps & ReviewSubmitButtonProps> 
     }
 
     // Can SUBMIT
-    showConfirmModal({ ...messages.REVIEW_SUBMISSION_CONFIRM })
+    showConfirmModal({ ...messages.REVIEW_SUBMISSION_CONFIRM, onConfirm: () => submission() })
   }
 
   const submission = async () => {


### PR DESCRIPTION
Urgent fix for this.

It's another stale closure problem, @nmadruga -- by defining the ` onConfirm: () => submission()` in the initial instantiation of the "useConfirmationModal", the `submission` function was using the result of "getDecision" from when it was instantiated, not the current one.

So just needed to make sure the confirmation modal got the *current* state by moving it's call inside the "onClick" instead. So now the "getDecision" result will be newly generated and passed to the confirmation modal when "onClick" is run, not when the modal hook is first loaded.

FYI -- if you want to quickly see the effect of this change, just temporarily change the "submission" function to this:
```ts
const submission = async () => {
    try {
      console.log("Decision will be", getDecision())
      // await submitReview(structure, getDecision())
    } catch (e) {
      console.log(e)
      setSubmissionError(true)
    }
  }
```

Then notice what gets printed to the console when running it on `develop` vs running on this branch ;)

As a general rule, when using the `useConfirmationModal` hook, parameters passed in when instantiated should be for things that don't change. For dynamic values, pass them in when calling the "showModal" method.

