### PR TITLE
Extra warnings for snapshots

### DIFF
--- a/src/utils/hooks/useConfirmationModal.tsx
+++ b/src/utils/hooks/useConfirmationModal.tsx
@@ -11,6 +11,7 @@ interface ConfirmModalState extends ModalProps {
   onConfirm: () => void
   onCancel: () => void
   showCancel: boolean
+  awaitAction: boolean
 }
 
 const useConfirmationModal = ({
@@ -22,6 +23,7 @@ const useConfirmationModal = ({
   onConfirm,
   onCancel,
   showCancel = true,
+  awaitAction = true,
   ...modalProps
 }: Partial<ConfirmModalState> = {}) => {
   const { strings } = useLanguageProvider()
@@ -36,13 +38,19 @@ const useConfirmationModal = ({
     onConfirm: onConfirm ? onConfirm : () => console.log('Clicked OK'),
     onCancel: onCancel ? onCancel : () => {},
     showCancel,
+    awaitAction,
   })
 
   const handleConfirm = async (confirmFunction: () => void) => {
-    setButtonLoading(true)
-    await confirmFunction()
-    setButtonLoading(false)
-    setOpen(false)
+    if (modalState.awaitAction) {
+      setButtonLoading(true)
+      await confirmFunction()
+      setButtonLoading(false)
+      setOpen(false)
+    } else {
+      confirmFunction()
+      setOpen(false)
+    }
   }
 
   const handleCancel = async (cancelFunction: () => void) => {
@@ -99,6 +107,7 @@ const useConfirmationModal = ({
     onConfirm,
     onCancel,
     showCancel,
+    awaitAction,
   }: Partial<ConfirmModalState> = {}) => {
     const newState: Partial<ConfirmModalState> = {}
     if (title) newState.title = title
@@ -108,6 +117,7 @@ const useConfirmationModal = ({
     if (onConfirm) newState.onConfirm = onConfirm
     if (onCancel) newState.onCancel = onCancel
     if (showCancel !== undefined) newState.showCancel = showCancel
+    if (awaitAction) newState.awaitAction = awaitAction
     setModalState({ ...modalState, ...newState })
     setOpen(true)
   }


### PR DESCRIPTION
In light of my absent-minded blitz of the demo server earlier today, I thought it would be helpful to have some extra warnings when loading a snapshot. I've made it so the warning only shows when you're on a Production build -- that way it should be really obvious.

Warning for overwriting a snapshot too.

Note: I *haven't* added a warning for deletion, as you normally want to delete a whole bunch at once as part of a "clean-up", and it'll be a real hassle to have an extra click for each one. Plus, it shouldn't be a big deal to delete a snapshot as you should always have a copy elsewhere.


@fergie-nz if you want to test this, just temporarily set `const isProductionBuild = !config.isProductionBuild` to reverse the effect, so the confirmations will show locally.