### PR TITLE
#953B - Part2  generate review assignments action not auto assign final decision

### DIFF
--- a/docs/internal/Level-1+-Reviews-and-Changes-Requested.md
+++ b/docs/internal/Level-1+-Reviews-and-Changes-Requested.md
@@ -71,7 +71,6 @@ Currently we don't allow submitting directly to Applicant when there is a disagr
   - in the list of applications the action `VIEW_REVIEW` is available for this user now (review is not editable)
 * On review level 2 **self-assign**:
   - update `review_assignment` status `ASSIGNED`
-  - update other `review_assignment` with status `AVAILABLE` to have isLocked = True to inform front end that other reviews cannot be assigned
   - create `review_question_assignment` to each `review_response` that have latest status as `SUBMITTED` (to get only from submitted reviews)
   - in the list of applications the action `START_REVIEW` is available for this user
 * On review level 2 **start**:

--- a/src/components/Review/ReviewSectionRowAssigned.tsx
+++ b/src/components/Review/ReviewSectionRowAssigned.tsx
@@ -33,7 +33,6 @@ const ReviewSectionRowAssigned: React.FC<ReviewSectionComponentProps> = ({
         ) : (
           <ReviewSelfAssignmentLabel reviewer={assignment?.assignee} strings={strings} />
         )
-      case ReviewAction.canSelfAssignLocked:
       case ReviewAction.canContinueLocked:
         return isAssignedToCurrentUser ? (
           <ReviewLockedLabel strings={strings} />

--- a/src/containers/Review/ReviewPage.tsx
+++ b/src/containers/Review/ReviewPage.tsx
@@ -329,7 +329,7 @@ const PreviousStageDecision: React.FC<PreviousStageDecisionProps> = ({
     <Segment.Group horizontal id="previous-review">
       <Segment>
         <Header as="h3">{strings.LABEL_PREVIOUS_REVIEW}:</Header>
-        <ReviewByLabel user={review.reviewer} strings={strings} />
+        <ReviewByLabel user={review.reviewer} isSubmitted={true} strings={strings} />
         <Button
           className="button-med"
           as={Link}

--- a/src/utils/graphql/fragments/reviewAssignment.fragment.ts
+++ b/src/utils/graphql/fragments/reviewAssignment.fragment.ts
@@ -7,7 +7,6 @@ export default gql`
     timeUpdated
     levelNumber
     reviewerId
-    isLocked
     isLastLevel
     isFinalDecision
     isSelfAssignable

--- a/src/utils/helpers/structure/generateReviewSectionActions.ts
+++ b/src/utils/helpers/structure/generateReviewSectionActions.ts
@@ -29,7 +29,6 @@ type ActionDefinition = {
     reviewStatus: ReviewStatus | undefined
     isReviewActive: boolean
     isSelfAssignable: boolean
-    isLocked: boolean
   }) => boolean
 }
 
@@ -79,13 +78,8 @@ const actionDefinitions: ActionDefinition[] = [
   },
   {
     action: ReviewAction.canSelfAssign,
-    checkMethod: ({ reviewAssignmentStatus, isSelfAssignable, isLocked }) =>
-      reviewAssignmentStatus === ReviewAssignmentStatus.Available && isSelfAssignable && !isLocked,
-  },
-  {
-    action: ReviewAction.canSelfAssignLocked,
-    checkMethod: ({ reviewAssignmentStatus, isSelfAssignable, isLocked }) =>
-      reviewAssignmentStatus === ReviewAssignmentStatus.Available && isSelfAssignable && isLocked,
+    checkMethod: ({ reviewAssignmentStatus, isSelfAssignable }) =>
+      reviewAssignmentStatus === ReviewAssignmentStatus.Available && isSelfAssignable,
   },
   {
     action: ReviewAction.canContinue,
@@ -117,7 +111,6 @@ const generateReviewSectionActions: GenerateSectionActions = ({
     isFinalDecisionOnConsolidation,
     assignmentStatus,
     isSelfAssignable,
-    isLocked,
   },
   thisReview,
   currentUserId,
@@ -151,7 +144,6 @@ const generateReviewSectionActions: GenerateSectionActions = ({
       isPendingReview: (totalPendingReview || 0) > 0,
       isReviewActive: (totalActive || 0) > 0,
       isSelfAssignable,
-      isLocked,
     }
 
     const foundAction = actionDefinitions.find(({ checkMethod }) => checkMethod(checkMethodProps))

--- a/src/utils/hooks/useGetReviewInfo.tsx
+++ b/src/utils/hooks/useGetReviewInfo.tsx
@@ -87,7 +87,6 @@ const useGetReviewInfo = ({ applicationId, serial, skip = false }: UseGetReviewI
         isFinalDecision,
         isLastLevel,
         isSelfAssignable,
-        isLocked,
       } = reviewAssignment
 
       const stage = {
@@ -112,7 +111,6 @@ const useGetReviewInfo = ({ applicationId, serial, skip = false }: UseGetReviewI
         isFinalDecision: !!isFinalDecision,
         isLastLevel: !!isLastLevel,
         isSelfAssignable: !!isSelfAssignable,
-        isLocked: !!isLocked,
         allowedSections: (allowedSections as string[]) || [],
         assignedSections: assignedSections as string[],
         review: review

--- a/src/utils/hooks/useGetReviewStructureForSection/helpers.tsx
+++ b/src/utils/hooks/useGetReviewStructureForSection/helpers.tsx
@@ -148,7 +148,6 @@ const setIsNewApplicationResponse = (structure: FullStructure) => {
 const setReviewAndAssignment = (structure: FullStructure, reviewAssignment: AssignmentDetails) => {
   const {
     isLastLevel,
-    isLocked,
     isFinalDecision,
     isSelfAssignable,
     review,
@@ -171,7 +170,6 @@ const setReviewAndAssignment = (structure: FullStructure, reviewAssignment: Assi
     assignmentDate: reviewAssignment.current.timeStatusUpdated,
     assignedSections: reviewAssignment.assignedSections,
     isLastLevel,
-    isLocked,
     isSelfAssignable,
     isFinalDecision,
     isFinalDecisionOnConsolidation: isPreviousStageConsolidation,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -152,7 +152,6 @@ interface AssignmentDetails {
   isFinalDecision: boolean
   isLastLevel: boolean
   isSelfAssignable: boolean
-  isLocked: boolean
   allowedSections: string[]
   assignedSections: string[]
 }
@@ -402,7 +401,6 @@ interface ReviewAssignment {
   assignedSections: string[]
   canSubmitReviewAs?: Decision | null
   isLastLevel: boolean
-  isLocked: boolean
   isSelfAssignable: boolean
   isFinalDecision: boolean
   isFinalDecisionOnConsolidation: boolean
@@ -491,7 +489,6 @@ enum ReviewAction {
   canView = 'CAN_VIEW',
   canReReview = 'CAN_RE_REVIEW',
   canSelfAssign = 'CAN_SELF_ASSIGN',
-  canSelfAssignLocked = 'CAN_SELF_ASSIGN_LOCKED',
   canStartReview = 'CAN_START_REVIEW',
   canReStartReview = 'CAN_RE_START_REVIEW', // User for second review (for consolidator)
   canContinueLocked = 'CAN_CONTINUE_LOCKED',


### PR DESCRIPTION
Front-end part of [PR #943-part2](https://github.com/openmsupply/conforma-server/pull/955)

### Changes
- Remove use of `isLocked` for ReviewAssignment in Front-end, not in use
- Also removes related action to ASSIGN_LOCKED
- Easy fix to show "Submitted by" in Final decision (not super related)