### PR TITLE
#1429 Template builder fallbacks fixes

### DIFF
--- a/src/containers/TemplateBuilder/evaluatorGui/EvaluationFallback.tsx
+++ b/src/containers/TemplateBuilder/evaluatorGui/EvaluationFallback.tsx
@@ -12,7 +12,7 @@ type EvaluationOutputTypeProps = {
 const EvaluationFallback: React.FC<EvaluationOutputTypeProps> = ({ evaluation, setEvaluation }) => {
   const { fallback } = evaluation.asOperator
 
-  const [fallbackEnabled, setFallbackEnabled] = useState(!!fallback)
+  const [fallbackEnabled, setFallbackEnabled] = useState(fallback !== undefined)
   if (evaluation.type !== 'operator') return null
 
   const setFallback = (fallbackValue?: any) => {
@@ -26,8 +26,21 @@ const EvaluationFallback: React.FC<EvaluationOutputTypeProps> = ({ evaluation, s
     <div className="flex-row-start-center">
       <ComponentLibrary.Checkbox
         title="Enable Fallback"
-        checked={!!fallback}
-        setChecked={() => setFallbackEnabled(!fallbackEnabled)}
+        checked={fallbackEnabled}
+        setChecked={() => {
+          const newState = !fallbackEnabled
+          if (newState)
+            setEvaluation({
+              ...evaluation,
+              asOperator: { ...evaluation.asOperator, fallback: null },
+            })
+          else
+            setEvaluation({
+              ...evaluation,
+              asOperator: { ...evaluation.asOperator, fallback: undefined },
+            })
+          setFallbackEnabled(newState)
+        }}
         minLabelWidth={110}
       />
       {fallbackEnabled && (

--- a/src/containers/TemplateBuilder/evaluatorGui/guiDefinitions.tsx
+++ b/src/containers/TemplateBuilder/evaluatorGui/guiDefinitions.tsx
@@ -215,17 +215,36 @@ export const guis: GuisType = [
       children: ['firstName', null],
     }),
     match: (typedEvaluation) => typedEvaluation.asOperator.operator === 'objectProperties',
-    render: (evaluation, setEvaluation, ComponentLibrary, evaluatorParameters) => (
-      <React.Fragment key="objectProperties">
-        <ComponentLibrary.Label key="objectPath" title="Object path (e.g. thisResponse.text): " />
-        {renderSingleChild(evaluation, 0, setEvaluation, ComponentLibrary, evaluatorParameters)}
-        <ComponentLibrary.Label
-          key="fallback"
-          title="Fallback (in case object path is not found): "
-        />
-        {renderSingleChild(evaluation, 1, setEvaluation, ComponentLibrary, evaluatorParameters)}
-      </React.Fragment>
-    ),
+    render: (evaluation, setEvaluation, ComponentLibrary, evaluatorParameters) => {
+      const isFallbackSpecified = evaluation.asOperator.children.length === 2
+      return (
+        <React.Fragment key="objectProperties">
+          <ComponentLibrary.Label key="objectPath" title="Object path (e.g. thisResponse.text): " />
+          {renderSingleChild(evaluation, 0, setEvaluation, ComponentLibrary, evaluatorParameters)}
+          <ComponentLibrary.Label
+            key="fallback"
+            title="Fallback (in case object path is not found): "
+          />
+          <ComponentLibrary.FlexRow key="internalFallback">
+            <ComponentLibrary.Checkbox
+              checked={isFallbackSpecified}
+              setChecked={(_) => {
+                if (isFallbackSpecified) setEvaluation(removeFromArray(evaluation, 1))
+                else setEvaluation(addToArray(evaluation, getTypedEvaluation(null)))
+              }}
+            />
+            {isFallbackSpecified &&
+              renderSingleChild(
+                evaluation,
+                1,
+                setEvaluation,
+                ComponentLibrary,
+                evaluatorParameters
+              )}
+          </ComponentLibrary.FlexRow>
+        </React.Fragment>
+      )
+    },
   },
   {
     selector: 'Object functions',


### PR DESCRIPTION
Fix #1429 

Two main fixes here:

### Global fallback switch
![Screenshot 2022-11-09 at 11 50 10 AM](https://user-images.githubusercontent.com/5456533/200692967-12dabda0-704d-40ac-a16f-501a0bd7db73.png)
- has a proper `null` value when first switched on
- toggling the switch off now correctly removes the property completely
- values of `null` are preserved in evaluation expression

### Object properties fallback parameter
![Screenshot 2022-11-09 at 11 52 23 AM](https://user-images.githubusercontent.com/5456533/200693273-0868317a-46bd-49d2-8f0a-b33d0bc386bf.png)
- can now be disabled (toggle switch) (which you'd want if using global fallback)

Easiest way to test is to just use the "Show as GUI" toggle to compare the state of the UI with what's actually stored in the expression. (And you can see how broken it is when using on develop)