### PR TITLE
#953 - Fix Self-assign showing after already assigned

### DIFF
--- a/src/containers/Review/assignment/AssignmentSectionRow.tsx
+++ b/src/containers/Review/assignment/AssignmentSectionRow.tsx
@@ -64,7 +64,6 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
   const assignmentOptions = getAssignmentOptions({
     assignments,
     sectionCode,
-    // elements,
     assignee: assignedSections?.[sectionCode]?.newAssignee,
   })
   if (!assignmentOptions) return null
@@ -135,17 +134,17 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
               setIsReassignment={setIsReassignment}
               setIsUnassignment={() => showModal({ onConfirm: () => unassignAssignee() })}
             />
+          ) : assignmentOptions.options.length === 0 ? (
+            <Label className="simple-label" content={strings.ASSIGNMENT_NOT_AVAILABLE} />
           ) : (
-            assignmentOptions.options.length > 0 && (
-              <>
-                <Label className="simple-label" content={strings.LABEL_REVIEWER} />
-                <AssigneeDropdown
-                  assignmentOptions={assignmentOptions}
-                  sectionCode={sectionCode}
-                  onChangeMethod={(selected: number) => onAssigneeSelection(selected)}
-                />
-              </>
-            )
+            <>
+              <Label className="simple-label" content={strings.LABEL_REVIEWER} />
+              <AssigneeDropdown
+                assignmentOptions={assignmentOptions}
+                sectionCode={sectionCode}
+                onChangeMethod={(selected: number) => onAssigneeSelection(selected)}
+              />
+            </>
           )}
         </Grid.Column>
       </Grid.Row>

--- a/src/containers/Review/assignment/AssignmentTab.tsx
+++ b/src/containers/Review/assignment/AssignmentTab.tsx
@@ -35,17 +35,12 @@ const AssignmentTab: React.FC<{
   const [filters, setFilters] = useState<Filters | null>(null)
   const [assignmentError, setAssignmentError] = useState<string | null>(null)
 
-  const {
-    error,
-    loading,
-    assignmentsFiltered,
-    assignmentGroupedLevel,
-    isFullyAssigned,
-  } = useLoadAssignments({
-    info: fullStructure.info,
-    sectionCodes,
-    filters,
-  })
+  const { error, loading, assignmentsFiltered, assignmentGroupedLevel, isFullyAssigned } =
+    useLoadAssignments({
+      info: fullStructure.info,
+      sectionCodes,
+      filters,
+    })
 
   if (error) return <Message error header={strings.ERROR_REVIEW_PAGE} list={[error]} />
 

--- a/src/containers/Review/assignment/useGetAssignmentOptions.ts
+++ b/src/containers/Review/assignment/useGetAssignmentOptions.ts
@@ -40,9 +40,13 @@ const useGetAssignmentOptions = () => {
       ({ allowedSections }) => allowedSections.length === 0 || allowedSections.includes(sectionCode)
     )
 
+    // Possible reviewers to show on dropdown, are either
+    // - Assignees that can be assigned by current assigner (keep all Available assignee because is considering Re-assignmet)
+    // - Self-assignemnt reviewer with the sectionCode in its availableSections ReviewAssignment record
     const currentUserAssignable = currentSectionAssignable.filter(
-      ({ isCurrentUserAssigner, isSelfAssignable, isCurrentUserReviewer }) =>
-        isCurrentUserAssigner || (isSelfAssignable && isCurrentUserReviewer)
+      ({ isCurrentUserAssigner, isSelfAssignable, isCurrentUserReviewer, availableSections }) =>
+        isCurrentUserAssigner ||
+        (isSelfAssignable && isCurrentUserReviewer && availableSections.includes(sectionCode))
     )
 
     const currentlyAssigned = assignments.find(

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -34,6 +34,7 @@ export default {
   ASSIGNED: 'assigned',
   ASSIGNED_TO: 'assigned to',
   ASSIGNMENT_NOT_ASSIGNED: 'Not assigned',
+  ASSIGNMENT_NOT_AVAILABLE: 'Assignment not available',
   ASSIGNMENT_YOURSELF: 'Yourself',
   ASSIGNMENT_ERROR_TITLE: 'Assignment update error',
   ASSIGNMENT_ERROR_GENERAL: 'Could not complete assignment',

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -263,6 +263,7 @@ export type Query = Node & {
   reviewIsLastLevel?: Maybe<Scalars['Boolean']>;
   reviewIsLastStage?: Maybe<Scalars['Boolean']>;
   reviewLevel?: Maybe<Scalars['Int']>;
+  reviewList?: Maybe<ReviewListConnection>;
   reviewResponseStageNumber?: Maybe<Scalars['Int']>;
   reviewReviewerId?: Maybe<Scalars['Int']>;
   reviewStage?: Maybe<Scalars['Int']>;
@@ -1900,6 +1901,20 @@ export type QueryReviewIsLastStageArgs = {
 /** The root query type which gives access points into the data universe. */
 export type QueryReviewLevelArgs = {
   reviewAssignmentId?: Maybe<Scalars['Int']>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryReviewListArgs = {
+  stageid?: Maybe<Scalars['Int']>;
+  reviewerid?: Maybe<Scalars['Int']>;
+  appstatus?: Maybe<ApplicationStatus>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  before?: Maybe<Scalars['Cursor']>;
+  after?: Maybe<Scalars['Cursor']>;
+  filter?: Maybe<ReviewListRecordFilter>;
 };
 
 
@@ -13176,6 +13191,47 @@ export type AssignmentListEdge = {
   cursor?: Maybe<Scalars['Cursor']>;
   /** The `AssignmentListRecord` at the end of the edge. */
   node?: Maybe<AssignmentListRecord>;
+};
+
+/** A filter to be used against `ReviewListRecord` object types. All fields are combined with a logical ‘and.’ */
+export type ReviewListRecordFilter = {
+  /** Filter by the object’s `applicationId` field. */
+  applicationId?: Maybe<IntFilter>;
+  /** Filter by the object’s `reviewerAction` field. */
+  reviewerAction?: Maybe<ReviewerActionFilter>;
+  /** Checks for all expressions in this list. */
+  and?: Maybe<Array<ReviewListRecordFilter>>;
+  /** Checks for any expressions in this list. */
+  or?: Maybe<Array<ReviewListRecordFilter>>;
+  /** Negates the expression. */
+  not?: Maybe<ReviewListRecordFilter>;
+};
+
+/** A connection to a list of `ReviewListRecord` values. */
+export type ReviewListConnection = {
+  __typename?: 'ReviewListConnection';
+  /** A list of `ReviewListRecord` objects. */
+  nodes: Array<Maybe<ReviewListRecord>>;
+  /** A list of edges which contains the `ReviewListRecord` and cursor to aid in pagination. */
+  edges: Array<ReviewListEdge>;
+  /** The count of *all* `ReviewListRecord` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** The return type of our `reviewList` query. */
+export type ReviewListRecord = {
+  __typename?: 'ReviewListRecord';
+  applicationId?: Maybe<Scalars['Int']>;
+  reviewerAction?: Maybe<ReviewerAction>;
+};
+
+/** A `ReviewListRecord` edge in the connection. */
+export type ReviewListEdge = {
+  __typename?: 'ReviewListEdge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `ReviewListRecord` at the end of the edge. */
+  node?: Maybe<ReviewListRecord>;
 };
 
 /** A filter to be used against `ReviewableQuestionsRecord` object types. All fields are combined with a logical ‘and.’ */
@@ -35788,7 +35844,7 @@ export type OrganisationFragment = (
 
 export type ReviewAssignmentFragment = (
   { __typename?: 'ReviewAssignment' }
-  & Pick<ReviewAssignment, 'id' | 'status' | 'timeUpdated' | 'levelNumber' | 'reviewerId' | 'isLastLevel' | 'isFinalDecision' | 'isSelfAssignable' | 'allowedSections' | 'assignedSections'>
+  & Pick<ReviewAssignment, 'id' | 'status' | 'timeUpdated' | 'levelNumber' | 'reviewerId' | 'isLastLevel' | 'isFinalDecision' | 'isSelfAssignable' | 'allowedSections' | 'assignedSections' | 'availableSections'>
 );
 
 export type ReviewResponseFragmentFragment = (
@@ -37327,6 +37383,7 @@ export const ReviewAssignmentFragmentDoc = gql`
   isSelfAssignable
   allowedSections
   assignedSections
+  availableSections
 }
     `;
 export const StageFragmentDoc = gql`

--- a/src/utils/graphql/fragments/reviewAssignment.fragment.ts
+++ b/src/utils/graphql/fragments/reviewAssignment.fragment.ts
@@ -13,5 +13,6 @@ export default gql`
     isSelfAssignable
     allowedSections
     assignedSections
+    availableSections
   }
 `

--- a/src/utils/hooks/useGetReviewInfo.tsx
+++ b/src/utils/hooks/useGetReviewInfo.tsx
@@ -84,6 +84,7 @@ const useGetReviewInfo = ({ applicationId, serial, skip = false }: UseGetReviewI
         reviewAssignmentAssignerJoins,
         allowedSections,
         assignedSections,
+        availableSections,
         isFinalDecision,
         isLastLevel,
         isSelfAssignable,
@@ -113,6 +114,7 @@ const useGetReviewInfo = ({ applicationId, serial, skip = false }: UseGetReviewI
         isSelfAssignable: !!isSelfAssignable,
         allowedSections: (allowedSections as string[]) || [],
         assignedSections: assignedSections as string[],
+        availableSections: availableSections as string[],
         review: review
           ? {
               id: review.id,

--- a/src/utils/hooks/useLoadAssignments.tsx
+++ b/src/utils/hooks/useLoadAssignments.tsx
@@ -56,7 +56,11 @@ const useLoadAssignments = ({
   const currentReviewLevel = Math.max(Number(Object.keys(assignmentGroupedLevel)))
 
   const isFullyAssigned = currentReviewLevel
-    ? calculateIsFullyAssigned(assignmentGroupedLevel[currentReviewLevel], sectionCodes)
+    ? !assignmentGroupedLevel[currentReviewLevel].some(
+        ({ availableSections }) =>
+          availableSections.length > 0 &&
+          sectionCodes.some((code) => availableSections.includes(code))
+      )
     : true
 
   return {
@@ -69,17 +73,3 @@ const useLoadAssignments = ({
 }
 
 export default useLoadAssignments
-
-const calculateIsFullyAssigned = (
-  currentLevelAssignments: AssignmentDetails[],
-  sectionCodes: string[]
-) => {
-  const assignedSections = new Set(
-    currentLevelAssignments
-      // .filter((assignment) => assignment.current.assignmentStatus === ReviewAssignmentStatus.Assigned)
-      .map((assignment) => assignment.assignedSections)
-      .flat()
-  )
-
-  return assignedSections.size >= sectionCodes.length
-}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -154,6 +154,7 @@ interface AssignmentDetails {
   isSelfAssignable: boolean
   allowedSections: string[]
   assignedSections: string[]
+  availableSections: string[]
 }
 
 interface AssignmentOptions {


### PR DESCRIPTION
Part of fix for https://github.com/openmsupply/conforma-server/issues/953

~~Pending: Back-end change to correctly set `availableSections` per ReviewAssignment TODO~~ (Should be done now)

### Brief explanation
Before we removed `isLocked` the ReviewAssignment for self-assignments knew it couldn't be assigned when the RA was locked (since already assigned to another), now we had to add this property which basically helps with that - and is clearer.

### Changes
- Added `availableSections` into ReviewAssignment fragment - now this is accessible in query `getReviewInfo`
- Check in `useLoadAssignments` hook to set `isFullyAssigned` - used for AssignAll - Should find if none of ReviewAssignment still have **availableSections** meaning it is Fully assigned...
- Check in `getAssignmentOptions` hook when is Self-assignment should also make sure **availableSections** include the SectionCode to display the option to Self-assign... 

This logic isn't the easiest to follow, but the general idea is that it needs to check the property availableSections of ReviewAssignments to determinate in UI if Self-assignment option should be displayed (since reviewers of Self-assignment only has access to their own ReviewAssignment). The code is different to display for AssignAll dropdown and for each section therefor the change in two places

### Tests

Use the snapshot `Fiji-test4` on our Fiji shared folder in `snapshot-for-testing-PR`.
You can try out assigning/Re-assigning and Self-assigning.
There are 2 templates with Final decision:
PR1 has 3 stages - last one is Final decision (after single-level review)
PR2 has 2 stages - last one is Final decision (after a consolidation)