### PR TITLE
#1446 Show manage menu based on contents

### DIFF
--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -205,7 +205,7 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({
             />
           </List.Item>
         )}
-        {isManager && (
+        {managementOptions.length > 0 && (
           <List.Item className={dropdownsState.manage.active ? 'selected-link' : ''}>
             <Dropdown
               text={strings.MENU_ITEM_MANAGE}


### PR DESCRIPTION
Fix #1446 

Very small change -- just changes the condition for the "Manage" menu appearance to whether there's anything in it or not. Everything else is already working how it should.

This allows us to show the "Remove user..." template in the Manage menu even if the current user doesn't have "isManager" permission.

![Screenshot 2022-11-21 at 12 29 54 PM](https://user-images.githubusercontent.com/5456533/202932410-475b9f8e-a742-4695-9aeb-f403cf64afe5.png)
