### PR TITLE
#1445 move checks for admin manager inside current user

### DIFF
--- a/src/components/Admin/Admin.tsx
+++ b/src/components/Admin/Admin.tsx
@@ -18,12 +18,12 @@ const Admin: React.FC = () => {
     match: { path },
   } = useRouter()
   const {
-    userState: { isAdmin, isLoading },
+    userState: { currentUser, isLoading },
   } = useUserState()
 
   if (isLoading) return <Loading />
 
-  if (!isAdmin) return <NoMatch />
+  if (!currentUser?.isAdmin) return <NoMatch />
 
   const adminOption = [
     {

--- a/src/components/Main/Footer.tsx
+++ b/src/components/Main/Footer.tsx
@@ -8,7 +8,7 @@ const logo = require('../../../images/logos/logo_512.png').default
 const Footer: React.FC = () => {
   const { latestSnapshot } = usePrefs()
   const {
-    userState: { isAdmin },
+    userState: { currentUser },
   } = useUserState()
 
   return (
@@ -22,7 +22,7 @@ const Footer: React.FC = () => {
           The mSupply Foundation
           <br />
           {`v${config.version}`}
-          {isAdmin && (
+          {currentUser?.isAdmin && (
             <>
               <br />
               {latestSnapshot}

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,7 +51,6 @@ const config = {
   localStorageJWTKey: 'persistJWT',
   applicantDeadlineCode: 'applicantDeadline',
   isProductionBuild,
-  defaultSystemManagerPermissionName: 'systemManager',
   debounceTimeout: 350, // milliseconds
 }
 

--- a/src/containers/Dev/UserSelection.tsx
+++ b/src/containers/Dev/UserSelection.tsx
@@ -40,9 +40,9 @@ const UserSelection: React.FC = () => {
     } else localStorage.setItem(config.localStorageJWTKey, loginResult.JWT)
 
     // Organisation login (auto-select first in list)
-    const { JWT, user, templatePermissions, permissionNames, orgList, isAdmin } = loginResult
+    const { JWT, user, templatePermissions, orgList } = loginResult
     if (orgList.length === 0) {
-      await onLogin(JWT, user, templatePermissions, permissionNames, orgList, isAdmin)
+      await onLogin(JWT, user, templatePermissions, orgList)
       return
     }
     const selectedOrg = orgList[0]
@@ -62,9 +62,7 @@ const UserSelection: React.FC = () => {
       verifyOrgResult.JWT,
       verifyOrgResult.user,
       verifyOrgResult.templatePermissions,
-      verifyOrgResult.permissionNames,
-      orgList,
-      verifyOrgResult.isAdmin
+      orgList
     )
   }
 

--- a/src/containers/User/Login.tsx
+++ b/src/containers/User/Login.tsx
@@ -66,8 +66,8 @@ const Login: React.FC = () => {
   }
 
   const finishLogin = async (loginPayload: LoginPayload) => {
-    const { JWT, user, templatePermissions, permissionNames, orgList, isAdmin } = loginPayload
-    await onLogin(JWT, user, templatePermissions, permissionNames, orgList, isAdmin)
+    const { JWT, user, templatePermissions, orgList } = loginPayload
+    await onLogin(JWT, user, templatePermissions, orgList)
     if (history.location?.state?.from) push(history.location.state.from)
     else push('/')
   }

--- a/src/containers/User/NonRegisteredLogin.tsx
+++ b/src/containers/User/NonRegisteredLogin.tsx
@@ -42,8 +42,8 @@ const NonRegisteredLogin: React.FC<NonRegisteredLoginProps> = ({ option, redirec
   }, [])
 
   const onLoginSuccess = async (loginResult: LoginPayload) => {
-    const { JWT, user, templatePermissions, permissionNames, orgList, isAdmin } = loginResult
-    await onLogin(JWT, user, templatePermissions, permissionNames, orgList, isAdmin)
+    const { JWT, user, templatePermissions, orgList } = loginResult
+    await onLogin(JWT, user, templatePermissions, orgList)
     if (option === 'register') push('/application/new?type=UserRegistration')
     else if (option === 'reset-password') push('/application/new?type=PasswordReset')
     else if (option === 'redirect' && redirect) push(redirect)

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -18,14 +18,14 @@ const defaultBrandLogo = require('../../../images/logos/conforma_logo_wide_white
 
 const UserArea: React.FC = () => {
   const {
-    userState: { currentUser, orgList, templatePermissions, isAdmin },
+    userState: { currentUser, orgList, templatePermissions },
     onLogin,
   } = useUserState()
   const {
     templatesData: { templates },
   } = useListTemplates(templatePermissions, false)
   const { dataViewsList } = useDataViewsList()
-  const { intReferenceDocs, extReferenceDocs } = useReferenceDocs(currentUser, isAdmin)
+  const { intReferenceDocs, extReferenceDocs } = useReferenceDocs(currentUser)
 
   if (!currentUser || currentUser?.username === config.nonRegisteredUser) return null
 
@@ -83,7 +83,7 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({
   })
   const { push, pathname } = useRouter()
   const {
-    userState: { isAdmin, isManager },
+    userState: { currentUser },
   } = useUserState()
 
   // Ensures the "selected" state of other dropdowns gets disabled
@@ -205,7 +205,7 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({
             />
           </List.Item>
         )}
-        {isManager && (
+        {currentUser?.isManager && (
           <List.Item className={dropdownsState.manage.active ? 'selected-link' : ''}>
             <Dropdown
               text={strings.MENU_ITEM_MANAGE}
@@ -216,7 +216,7 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({
             />
           </List.Item>
         )}
-        {isAdmin && (
+        {currentUser?.isAdmin && (
           <List.Item className={dropdownsState.admin.active ? 'selected-link' : ''}>
             <Dropdown
               text={strings.MENU_ITEM_CONFIG}
@@ -289,15 +289,15 @@ const OrgSelector: React.FC<{ user: User; orgs: OrganisationSimple[]; onLogin: F
   const handleChange = async (_: SyntheticEvent, { value: orgId }: any) => {
     await attemptLoginOrg({ orgId, onLoginOrgSuccess })
   }
+
   const onLoginOrgSuccess = async ({
     user,
     orgList,
     templatePermissions,
     JWT,
-    isAdmin,
     permissionNames,
   }: LoginPayload) => {
-    await onLogin(JWT, user, templatePermissions, permissionNames, orgList, isAdmin)
+    await onLogin(JWT, user, templatePermissions, permissionNames, orgList)
   }
   const dropdownOptions = orgs.map(({ orgId, orgName }) => ({
     key: orgId,

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -290,14 +290,8 @@ const OrgSelector: React.FC<{ user: User; orgs: OrganisationSimple[]; onLogin: F
     await attemptLoginOrg({ orgId, onLoginOrgSuccess })
   }
 
-  const onLoginOrgSuccess = async ({
-    user,
-    orgList,
-    templatePermissions,
-    JWT,
-    permissionNames,
-  }: LoginPayload) => {
-    await onLogin(JWT, user, templatePermissions, permissionNames, orgList)
+  const onLoginOrgSuccess = async ({ user, orgList, templatePermissions, JWT }: LoginPayload) => {
+    await onLogin(JWT, user, templatePermissions, orgList)
   }
   const dropdownOptions = orgs.map(({ orgId, orgName }) => ({
     key: orgId,

--- a/src/contexts/UserState.tsx
+++ b/src/contexts/UserState.tsx
@@ -16,9 +16,7 @@ type OnLogin = (
   JWT: string,
   user?: User,
   templatePermissions?: TemplatePermissions,
-  permissionNames?: string[],
-  orgList?: OrganisationSimple[],
-  isAdmin?: boolean
+  orgList?: OrganisationSimple[]
 ) => void
 
 export type UserActions =
@@ -100,12 +98,12 @@ export function UserProvider({ children }: UserProviderProps) {
     window.location.href = '/login'
   }
 
-  const onLogin: OnLogin = (JWT: string, user, templatePermissions, permissionNames, orgList) => {
+  const onLogin: OnLogin = (JWT: string, user, templatePermissions, orgList) => {
     // NOTE: quotes are required in 'undefined', refer to https://github.com/openmsupply/conforma-web-app/pull/841#discussion_r670822649
     if (JWT == 'undefined' || JWT == undefined) logout()
     dispatch({ type: 'setLoading', isLoading: true })
     localStorage.setItem(config.localStorageJWTKey, JWT)
-    if (!user || !templatePermissions || !permissionNames)
+    if (!user || !templatePermissions || !user.permissionNames)
       fetchUserInfo({ dispatch: setUserState }, logout)
     else {
       dispatch({

--- a/src/utils/helpers/fetchUserInfo.ts
+++ b/src/utils/helpers/fetchUserInfo.ts
@@ -10,13 +10,8 @@ interface SetUserInfoProps {
 }
 
 const fetchUserInfo = ({ dispatch }: SetUserInfoProps, logout: Function) => {
-  const { preferences } = usePrefs()
-
-  const managementPrefName =
-    preferences?.systemManagerPermissionName || config.defaultSystemManagerPermissionName
-
   getRequest(getServerUrl('userInfo'))
-    .then(({ templatePermissions, permissionNames, JWT, user, success, orgList, isAdmin }) => {
+    .then(({ templatePermissions, JWT, user, success, orgList }) => {
       if (!success) logout()
       localStorage.setItem(config.localStorageJWTKey, JWT)
       // Set userinfo to context after receiving it from endpoint
@@ -25,10 +20,7 @@ const fetchUserInfo = ({ dispatch }: SetUserInfoProps, logout: Function) => {
           type: 'setCurrentUser',
           newUser: user,
           newPermissions: templatePermissions || {},
-          newPermissionNames: permissionNames || [],
           newOrgList: orgList || [],
-          newIsAdmin: !!isAdmin,
-          newIsManager: permissionNames.includes(managementPrefName),
         })
       }
 

--- a/src/utils/hooks/useReferenceDocs.ts
+++ b/src/utils/hooks/useReferenceDocs.ts
@@ -9,7 +9,7 @@ interface RefDoc {
   isExternalReferenceDoc: boolean
 }
 
-export const useReferenceDocs = (currentUser: User | null, isAdmin: boolean) => {
+export const useReferenceDocs = (currentUser: User | null) => {
   const [intReferenceDocs, setIntReferenceDocs] = useState<RefDoc[]>([])
   const [extReferenceDocs, setExtReferenceDocs] = useState<RefDoc[]>([])
   const { data, loading, error } = useGetRefDocsQuery()
@@ -23,11 +23,11 @@ export const useReferenceDocs = (currentUser: User | null, isAdmin: boolean) => 
     if (!data || error) return
 
     if (data.files?.nodes) {
-      if (shouldSeeInternalDocs(currentUser, isAdmin))
+      if (shouldSeeInternalDocs(currentUser))
         setIntReferenceDocs(
           (data.files?.nodes as RefDoc[]).filter((doc) => doc.isInternalReferenceDoc)
         )
-      if (shouldSeeExternalDocs(currentUser, isAdmin))
+      if (shouldSeeExternalDocs(currentUser))
         setExtReferenceDocs(
           (data.files?.nodes as RefDoc[]).filter((doc) => doc.isExternalReferenceDoc)
         )
@@ -37,14 +37,14 @@ export const useReferenceDocs = (currentUser: User | null, isAdmin: boolean) => 
   return { intReferenceDocs, extReferenceDocs, loading, error }
 }
 
-const shouldSeeInternalDocs = (user: User, isAdmin: boolean): boolean => {
-  if (isAdmin) return true
+const shouldSeeInternalDocs = (user: User): boolean => {
+  if (!user?.isAdmin) return true
   if (!user?.organisation) return false
   return user.organisation.isSystemOrg
 }
 
-const shouldSeeExternalDocs = (user: User, isAdmin: boolean): boolean => {
-  if (isAdmin) return true
+const shouldSeeExternalDocs = (user: User): boolean => {
+  if (!user?.isAdmin) return true
   if (!user?.organisation) return true
   return !user.organisation.isSystemOrg
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -662,9 +662,7 @@ interface LoginPayload {
   user: User
   JWT: string
   templatePermissions: TemplatePermissions
-  permissionNames: string[]
   orgList?: OrganisationSimple[]
-  isAdmin: boolean
 }
 
 interface UseGetReviewStructureForSectionProps {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -638,7 +638,10 @@ interface User {
   email: string
   dateOfBirth?: Date | null
   organisation?: Organisation
+  permissionNames: string[]
   sessionId: string
+  isAdmin: boolean
+  isManager: boolean
 }
 
 interface OrganisationSimple {


### PR DESCRIPTION
Fixes #1445 

### Changes
- Moves `isAdmin`, `isManager` and `permissionNames` to be in the object for CurrentUser - which can be accessed by the applicationData on Elements
- No need to have preferences to determine the SystemManager in the Front-end anymore.

### Template using new changes
In case someone would like to test it
[removeUserOrg-5 (2).zip](https://github.com/openmsupply/conforma-web-app/files/10051855/removeUserOrg-5.2.zip)
