### PR TITLE
CSS tweaks / Image display improvement

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -310,7 +310,8 @@ a:hover {
 }
 
 #brand-area {
-  width: clamp(100px, 25%, 200px);
+  min-width: 100px;
+  max-width: 200px;
   display: flex;
   align-items: center;
   .brand-area-text {
@@ -379,7 +380,7 @@ a:hover {
 #org-selector .image {
   margin-right: 20px;
   height: 100%;
-  max-width: 100px;
+  max-width: 300px;
 }
 
 #user-menu .button {

--- a/src/formElementPlugins/imageDisplay/src/ApplicationView.tsx
+++ b/src/formElementPlugins/imageDisplay/src/ApplicationView.tsx
@@ -3,7 +3,7 @@ import { Image } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({ parameters }) => {
-  const { url, size, alignment, altText } = parameters
+  const { url, size, alignment, altText, style = {} } = parameters
 
   return (
     <Image
@@ -12,7 +12,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({ parameters }) => {
       // Have to do a bit of trickery in terms margin over-rides to get
       // right-alignment working
       centered={alignment === 'center' || alignment === 'right'}
-      style={alignment === 'right' ? { marginRight: 'unset' } : {}}
+      style={alignment === 'right' ? { marginRight: 'unset', ...style } : style}
       alt={altText}
       title={altText}
     />
@@ -21,4 +21,13 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({ parameters }) => {
 
 export default ApplicationView
 
-const allowedSizeValues = ['mini', 'tiny', 'small', 'medium', 'large', 'big', 'huge', 'massive']
+export const allowedSizeValues = [
+  'mini',
+  'tiny',
+  'small',
+  'medium',
+  'large',
+  'big',
+  'huge',
+  'massive',
+]

--- a/src/formElementPlugins/imageDisplay/src/SummaryView.tsx
+++ b/src/formElementPlugins/imageDisplay/src/SummaryView.tsx
@@ -1,18 +1,22 @@
 import React from 'react'
 import { Image } from 'semantic-ui-react'
+import { allowedSizeValues } from './ApplicationView'
 import { SummaryViewProps } from '../../types'
 
 const SummaryView: React.FC<SummaryViewProps> = ({ parameters }) => {
-  const { url, size, alignment, altText } = parameters
+  const { url, size, alignment, altText, summarySize = 'small' } = parameters
+
+  // By default, image is displayed "small" in Summary view, but can be
+  // over-ridden by specifying "summarySize"
 
   return (
     <Image
       src={url}
-      size="small" // Always show small in Summary view
+      size={allowedSizeValues.includes(summarySize) ? size : 'small'}
       // Have to do a bit of trickery in terms margin over-rides to get
       // right-alignment working
       centered={alignment === 'center' || alignment === 'right'}
-      style={alignment === 'right' ? { marginRight: 'unset' } : {}}
+      style={alignment === 'right' ? { marginRight: 'unset' } : { maxWidth: 100 }}
       alt={altText}
       title={altText}
     />

--- a/src/formElementPlugins/imageDisplay/src/SummaryView.tsx
+++ b/src/formElementPlugins/imageDisplay/src/SummaryView.tsx
@@ -4,7 +4,7 @@ import { allowedSizeValues } from './ApplicationView'
 import { SummaryViewProps } from '../../types'
 
 const SummaryView: React.FC<SummaryViewProps> = ({ parameters }) => {
-  const { url, size, alignment, altText, summarySize = 'small' } = parameters
+  const { url, size, alignment, altText, summarySize = 'small', style = {} } = parameters
 
   // By default, image is displayed "small" in Summary view, but can be
   // over-ridden by specifying "summarySize"
@@ -16,7 +16,7 @@ const SummaryView: React.FC<SummaryViewProps> = ({ parameters }) => {
       // Have to do a bit of trickery in terms margin over-rides to get
       // right-alignment working
       centered={alignment === 'center' || alignment === 'right'}
-      style={alignment === 'right' ? { marginRight: 'unset' } : { maxWidth: 100 }}
+      style={alignment === 'right' ? { marginRight: 'unset', ...style } : style}
       alt={altText}
       title={altText}
     />


### PR DESCRIPTION
Fix to better handle a wider range of logos in the Header bar.
![Screenshot 2022-11-22 at 3 39 27 PM](https://user-images.githubusercontent.com/5456533/203207684-87153b4e-cc79-4d86-96a5-90f419095348.png)
becomes:
![2022-11-22 15 38 22](https://user-images.githubusercontent.com/5456533/203207494-317f40f2-99e1-423a-9f0a-7ec587d6f87f.jpg)


I also took the opportunity to improve the Image Display element to allow custom styles to be passed in. This allows us to prevent this kind of thing:
![Screenshot 2022-11-22 at 3 34 07 PM](https://user-images.githubusercontent.com/5456533/203207349-174230b2-75af-4c0f-8a8c-00d9629c2540.png)

And restrict it to something like this::
![Screenshot 2022-11-22 at 3 33 02 PM](https://user-images.githubusercontent.com/5456533/203207373-f8791427-f8f8-4ea8-9f11-e11851ac6cb1.png)
