### PR TITLE
#1456 Extend deadline fix

### DIFF
--- a/src/containers/Review/overview/Overview.tsx
+++ b/src/containers/Review/overview/Overview.tsx
@@ -6,11 +6,7 @@ import useLocalisedEnums from '../../../utils/hooks/useLocalisedEnums'
 import useConfirmationModal from '../../../utils/hooks/useConfirmationModal'
 import { postRequest } from '../../../utils/helpers/fetchMethods'
 import { FullStructure } from '../../../utils/types'
-import {
-  ActivityLog,
-  ApplicationOutcome,
-  ApplicationStatus,
-} from '../../../utils/generated/graphql'
+import { ActivityLog, ApplicationOutcome } from '../../../utils/generated/graphql'
 import config from '../../../config'
 import getServerUrl from '../../../utils/helpers/endpoints/endpointUrlBuilder'
 

--- a/src/containers/Review/overview/Overview.tsx
+++ b/src/containers/Review/overview/Overview.tsx
@@ -89,8 +89,7 @@ export const Overview: React.FC<{
             </div>
             {applicantDeadline &&
               (outcome === ApplicationOutcome.Expired ||
-                current.status === ApplicationStatus.ChangesRequired ||
-                current.status === ApplicationStatus.Draft) && (
+                outcome === ApplicationOutcome.Pending) && (
                 <div className="flex-row-start-center" style={{ gap: 10, marginTop: 30 }}>
                   {strings.REVIEW_OVERVIEW_EXTEND_BY}
                   <Form.Input


### PR DESCRIPTION
Fix #1456 

I've just relaxed the condition a bit so that any application that is EXPIRED or PENDING (i.e. not APPROVED, REJECTED or WITHDRAWN) will show the "Extend deadline" UI.

I think this is okay, but please let me know if you think of any use cases where this is not appropriate.

Can test with Angola ProdReg --- submit an application and the "extend" option should be available to reviewers (it wasn't previously)

(Sorry, I based this off `feature/core-actions` -- I know it should really be from `develop`, but it's too hard to find and use a snapshot in the old state and switch back and forth consistently without messing something up. Hopefully we'll merge the whole feature branch to develop soon anyway)