### PR TITLE
#1454 Make AssignerAction filter available on UI

### DIFF
--- a/src/utils/helpers/list/useGetFilterDefinitions.ts
+++ b/src/utils/helpers/list/useGetFilterDefinitions.ts
@@ -173,7 +173,7 @@ export const useGetFilterDefinitions = () => {
     assignerAction: {
       type: 'enumList',
       default: defaultFilters.some((filter) => filter === 'assignerAction'),
-      visibleTo: [],
+      visibleTo: [USER_ROLES.REVIEWER],
       title: strings.FILTER_ASSIGNER_ACTION,
       options: { enumList: Object.values(AssignerAction) },
     },


### PR DESCRIPTION
Fixes #1454 

Based on `feature/core-actions` branch - which is planned to be merged by tomorrow 🤞 

Quick fix to allow reviewers to have AssignerAction filter visible on the UI