### PR TITLE
1459 Fix review history panel

### DIFF
--- a/src/utils/hooks/useGetQuestionReviewHistory.tsx
+++ b/src/utils/hooks/useGetQuestionReviewHistory.tsx
@@ -77,6 +77,7 @@ const useGetQuestionReviewHistory = ({ isApplicant, ...variables }: UseGetQuesti
 
       // Set each entry using HistoryElement values
       if (stageNumber) {
+        if (!allResponsesByStage[stageNumber]) allResponsesByStage[stageNumber] = []
         allResponsesByStage[stageNumber].push({
           author: reviewer ? reviewer?.firstName || '' + ' ' + reviewer?.lastName || '' : '',
           title:


### PR DESCRIPTION
Fix #1459 

Turned out to be pretty simple. Seems I overlooked (and didn't check) for stages which only have review responses and not application responses, in which case the `allResponsesByStage[stageNumber]` would be not defined yet. So we just create an empty array, like we already do for  the applicationResponses above this block.