### PR TITLE
Improve deadline extend button condition

### DIFF
--- a/src/containers/Review/overview/Overview.tsx
+++ b/src/containers/Review/overview/Overview.tsx
@@ -84,8 +84,11 @@ export const Overview: React.FC<{
               )}
             </div>
             {applicantDeadline &&
-              (outcome === ApplicationOutcome.Expired ||
-                outcome === ApplicationOutcome.Pending) && (
+              // If the deadline is active, then it must be PENDING. If it's
+              // inactive, then we only want to show the button when it's
+              // EXPIRED, so cancelled deadlines don't cause the button to show.
+              ((applicantDeadline.isActive && outcome === ApplicationOutcome.Pending) ||
+                (!applicantDeadline.isActive && outcome === ApplicationOutcome.Expired)) && (
                 <div className="flex-row-start-center" style={{ gap: 10, marginTop: 30 }}>
                   {strings.REVIEW_OVERVIEW_EXTEND_BY}
                   <Form.Input


### PR DESCRIPTION
Quick fix for problem @jagoje discovered -- the "Extend deadline" button was still visible even though the deadline had been "Cancelled" due to the application being assigned.

Have added additional condition logic so that "cancelled" (i.e. `is_active = false`) deadlines only allow the button to appear if the application is "Expired". This way we can distinguish between applications that have inactive deadlines due to expiration (i.e. can be "unexpired" using this UI), or inactive due to "cancellation" (i.e. the deadline is effectively "gone" and shouldn't be visible in the UI at all)