### PR TITLE
Custom header colour option

### DIFF
--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -17,6 +17,7 @@ import { UiLocation } from '../../utils/generated/graphql'
 const defaultBrandLogo = require('../../../images/logos/conforma_logo_wide_white_1024.png').default
 
 const UserArea: React.FC = () => {
+  const { preferences } = usePrefs()
   const {
     userState: { currentUser, orgList, templatePermissions },
     onLogin,
@@ -30,7 +31,12 @@ const UserArea: React.FC = () => {
   if (!currentUser || currentUser?.username === config.nonRegisteredUser) return null
 
   return (
-    <Container id="user-area" fluid>
+    <Container
+      id="user-area"
+      fluid
+      // Custom color option (for Angola only currently)
+      style={{ backgroundColor: preferences?.style?.headerBgColor ?? '' }}
+    >
       <BrandArea />
       <div id="user-area-left">
         <MainMenuBar

--- a/src/contexts/SystemPrefs.tsx
+++ b/src/contexts/SystemPrefs.tsx
@@ -12,6 +12,7 @@ interface PrefsState {
     brandLogoOnDarkFileId?: string
     defaultListFilters?: string[]
     systemManagerPermissionName?: string
+    style?: { headerBgColor?: string }
   }
   languageOptions?: LanguageOption[]
   latestSnapshot?: string


### PR DESCRIPTION
Allows the header bar background colour to be over-ridden from preferences.

I'd like to have a proper theming system at some point, so don't want to go too far down this "gambiarra" fix, but this will do for this immediate requirement.

Back-end "preferences.json" should have an extra "style" field in the "web" section, for example:
```
"web": {
    "paginationPresets": [2, 5, 10, 20, 50],
    "defaultLanguageCode": "pt_an",
    "brandLogoFileId": "LAGjTbhANrjT3x1c-7Co2",
    "brandLogoOnDarkFileId": "c3riQ1PDSSRBhR1NeBA4O",
    "defaultListFilters": ["applicantDeadline", "reviewers", "reviewerAction", "stage"],
    "style": {
       "headerBgColor": "#390B89"
    }
  }
```