### PR TITLE
#997B Prevent crash when displaying json data in lookup tables

### DIFF
--- a/src/LookupTable/components/single/LookUpTable.tsx
+++ b/src/LookupTable/components/single/LookUpTable.tsx
@@ -38,11 +38,22 @@ const LookupTable: React.FC<any> = ({ structure }) => {
             return (
               <Table.Row key={`lookup-table-${structure.tableName}-row-${myDataRow.id}`}>
                 {structure &&
-                  structure.fieldMap.map((field: FieldMapType) => (
-                    <Table.Cell key={`lookup-table-${structure.tableName}-data-${field.fieldname}`}>
-                      {myDataRow[toCamelCase(field.fieldname)]}
-                    </Table.Cell>
-                  ))}
+                  structure.fieldMap.map((field: FieldMapType) => {
+                    const value = myDataRow[toCamelCase(field.fieldname)]
+                    const displayString =
+                      value === null
+                        ? ''
+                        : typeof value === 'object'
+                        ? JSON.stringify(value)
+                        : String(value)
+                    return (
+                      <Table.Cell
+                        key={`lookup-table-${structure.tableName}-data-${field.fieldname}`}
+                      >
+                        {displayString}
+                      </Table.Cell>
+                    )
+                  })}
               </Table.Row>
             )
           })


### PR DESCRIPTION
Front-end fix required for back-end PR https://github.com/openmsupply/conforma-server/pull/1003

Now that lookup tables can have data types other than `varchar`/`string`, the table display component was crashing as it couldn't handle the "object" data.

This just stringifies it for display.