### PR TITLE
#1469 #1474 Plugin updates to handle complex pre-filling

### DIFF
--- a/docs/internal/config/Element-Type-Specs.md
+++ b/docs/internal/config/Element-Type-Specs.md
@@ -72,6 +72,7 @@ _Free-form, single-line text input element_
 - **description**: `string` -- additional explanatory text (usually not required) [Optional]
 - **placeholder**: `string`-- text to display before user input (HTML "placeholder" attribute) [Optional]
 - **default**: `string` -- default response, will change dynamically in response to form changes until the user has edited it [Optional]
+- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
 - **maskedInput**: `boolean` -- if `true`, displays user input as masked (hidden) characters -- i.e. for passwords. [Optional]
 - **maxWidth**: `number` -- the maximum width (in pixels) for the text input box (defaults to fill the width of the container)
 - **maxLength**: `number` -- response must be no longer than this many characters. If the user tries to type more, the response will be truncated to the maximum length.  
@@ -113,6 +114,7 @@ _Free-form, multi-line text input element_
 - **description**: `string` -- additional explanatory text (usually not required) [Optional]
 - **placeholder**: `string`-- text to display before user input (HTML "placeholder" attribute) [Optional]
 - **default**: `string` -- default response, will change dynamically in response to form changes until the user has edited it [Optional]
+- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
 - **lines**: `number` -- height of the TextArea input, in number of lines/rows (default: 5)
 - **maxLength**: `number` -- response must be no longer than this many characters. If the user tries to type more, the response will be truncated to the maximum length. (See Note in ShortText above for how to integrate `maxLength` with validation.)
 
@@ -248,7 +250,8 @@ _Multi-choice question, with one allowed option, displayed as Drop-down list (Co
 - **label**: `string` -- as above
 - **description**: `string` -- as above [Optional]
 - **options**: `array[string | object]` -- array of options for the user to select from. If an array of **strings** is provided, these strings will be displayed to the user. However, if an array of **objects** is provided, you will also need to specify an `optionsDisplayProperty` (see below)
-- **default**: `string`/`number` -- if not provided, defaults to index 0.
+- **default**: `string`/`number` -- can be either a string representing the *value*, or a number representing the index in the `options` array. [Optional]
+- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
 - **search**: `boolean` (default: `false`) -- if `true`, the list of options can be searched and filtered by user
 - **optionsDisplayProperty**: If `options` (above) consists of an array of objects, this parameter specifies the field of each object to be displayed in the options list. For example, if `options` was a list of organisation objects (i.e. `{orgId, name, licenceNumber}`), you'd probably specify `name` as the `optionsDisplayProperty`. Note that even though one field is displayed to the user in the Dropdown list, the _entire_ selected object is saved as the selection. And if `optionsDisplayProperty` refers to a field that doesn't exist on the supplied object, the plugin will fail and show in error in the application.
 - **hasOther**: `boolean` (default `false`) -- if `true`, allows the user to enter a custom "free text" value instead of one of the pre-defined options.
@@ -282,6 +285,7 @@ _Multi-choice question, with one allowed selection, displayed as labelled radio 
 - **description**: `string` -- as above [Optional]
 - **options**: `array[string | object]` -- as above (in [Drop-down](#dropdown))
 - **default**: `string`/`number` -- the value initially selected before user input. If `number`, refers to the index of the options array. If not provided, no options will be pre-selected.
+- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
 - **optionsDisplayProperty**: -- as above (in Drop-down)
 - **layout**: `string` -- if "inline", displays radio buttons horizontally, rather than stacked vertically (default)
 - **hasOther**: `boolean` (default `false`) -- if `true`, displays an additional "Other" option with a free text field for inputting additional user-defined option.
@@ -442,6 +446,8 @@ _Allows user to build a list of items, such as an **Ingredients List**_
 
 - **label**: `string` -- as above
 - **description**: `string` -- as above [Optional]
+- **default** `ResponseList` -- default value for the list. Must be in the format of the `list` parameter from the Response object (i.e. an array of objects)
+- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
 - **createModalButtonText** `string` -- text to display on the button to launch the new item interface (modal) (default: "Add item")
 - **addButtonText** `string` -- text to display on the button to add a new item from the item editing modal (default: "Add")
 - **updateButtonText** `string` -- text to display on the button to update an existing item from the item editing modal (default: "Update")
@@ -555,7 +561,8 @@ Once selected, items are displayed in a "card" view:
     children: [ "search.text" ]
   }
   ```
-
+- **default** `ResponseSelection` / `ResponseSelection[]` -- default value for the selection(s). Must be in the format of the `selection` parameter from the Response object (i.e. an array of objects), or just a single object if not multi-select.
+- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
 - **icon**: `string` -- the name of the icon shown in the search box, from Semantic-UI icons. (default: "search" : 🔍 )
 - **multiSelect**: `boolean` -- whether or not the user can select multiple items for their response (default: `false`)
 - **minCharacters**: `number` -- the minimum number of characters the user must type before the search query executes (default: 1). This is useful in situations where need the user to look up a specific item without being able to freely browse through the entire results list. For example, to look up organisation in our system using "registration" code, we set `minCharacters = 6`, so the user will need to know an exact code rather than being able to try characters one at a time.
@@ -605,6 +612,7 @@ Uses [React Semantic-UI Datepickers](https://www.npmjs.com/package/react-semanti
 - **label**: `string` -- as above
 - **description**: `string` -- as above [Optional]
 - **default**: `(ISO) string` -- a pre-selected date [Optional]
+- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
 - **allowRange**: `boolean` -- if `true`, input is expected to be a date _range_ (a start and end date). Default: `false` (i.e. can only enter single date)
 - **minDate**/**maxDate**: `(ISO) string` -- specifies how far into the future or past the selector can go
 - **minAge**/**maxAge**: `(ISO) string` -- same as above, but a number (in years) relative to the _current_ date. For example, if an applicant was required to be over 18 years old, you'd set `minAge` to `18`.
@@ -640,7 +648,8 @@ _Input for numeric fields_
 #### Input parameters
 
 - **label** / **description** / **placeholder** / **maxWidth**: `string` -- as above
-- **default** -- default value (Note: if you require a dynamic value for "default", please use the "defaultValue" field on `template_element`)
+- **default**: `string`/`number` -- default value 
+- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
 - **type** -- `enum` -- either "integer" or "float" (default: "integer")
 - **simple** -- `boolean` (default: `true`) If `true`, the input field will always show only a non-formatted version of the number (i.e. "1000", not "1,000"), but it will have a "stepper" which can be clicked to increment the number up and down.
 - **minValue** -- minimum allowed value (default: 0)
@@ -685,12 +694,3 @@ _For specifying where the list of questions is broken into UI pages/steps. The *
 - ~~**pageBreakValidityCheck**: `boolean` -- If `true`, the user cannot proceed to the next page unless _all_ questions on the current page have passed validation~~
   - ~~default: `false`~~
 
----
-
-```
-
-```
-
-```
-
-```

--- a/docs/internal/config/Element-Type-Specs.md
+++ b/docs/internal/config/Element-Type-Specs.md
@@ -72,7 +72,7 @@ _Free-form, single-line text input element_
 - **description**: `string` -- additional explanatory text (usually not required) [Optional]
 - **placeholder**: `string`-- text to display before user input (HTML "placeholder" attribute) [Optional]
 - **default**: `string` -- default response, will change dynamically in response to form changes until the user has edited it [Optional]
-- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
+- **persistUserInput**: `boolean` -- if `false`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`true`), the default will only be used if there is no response yet. [Optional; default `false`]
 - **maskedInput**: `boolean` -- if `true`, displays user input as masked (hidden) characters -- i.e. for passwords. [Optional]
 - **maxWidth**: `number` -- the maximum width (in pixels) for the text input box (defaults to fill the width of the container)
 - **maxLength**: `number` -- response must be no longer than this many characters. If the user tries to type more, the response will be truncated to the maximum length.  
@@ -114,7 +114,7 @@ _Free-form, multi-line text input element_
 - **description**: `string` -- additional explanatory text (usually not required) [Optional]
 - **placeholder**: `string`-- text to display before user input (HTML "placeholder" attribute) [Optional]
 - **default**: `string` -- default response, will change dynamically in response to form changes until the user has edited it [Optional]
-- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
+- **persistUserInput**: `boolean` -- if `false`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`true`), the default will only be used if there is no response yet. [Optional; default `false`]
 - **lines**: `number` -- height of the TextArea input, in number of lines/rows (default: 5)
 - **maxLength**: `number` -- response must be no longer than this many characters. If the user tries to type more, the response will be truncated to the maximum length. (See Note in ShortText above for how to integrate `maxLength` with validation.)
 
@@ -251,7 +251,7 @@ _Multi-choice question, with one allowed option, displayed as Drop-down list (Co
 - **description**: `string` -- as above [Optional]
 - **options**: `array[string | object]` -- array of options for the user to select from. If an array of **strings** is provided, these strings will be displayed to the user. However, if an array of **objects** is provided, you will also need to specify an `optionsDisplayProperty` (see below)
 - **default**: `string`/`number` -- can be either a string representing the *value*, or a number representing the index in the `options` array. [Optional]
-- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
+- **persistUserInput**: `boolean` -- if `false`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`true`), the default will only be used if there is no response yet. [Optional; default `false`]
 - **search**: `boolean` (default: `false`) -- if `true`, the list of options can be searched and filtered by user
 - **optionsDisplayProperty**: If `options` (above) consists of an array of objects, this parameter specifies the field of each object to be displayed in the options list. For example, if `options` was a list of organisation objects (i.e. `{orgId, name, licenceNumber}`), you'd probably specify `name` as the `optionsDisplayProperty`. Note that even though one field is displayed to the user in the Dropdown list, the _entire_ selected object is saved as the selection. And if `optionsDisplayProperty` refers to a field that doesn't exist on the supplied object, the plugin will fail and show in error in the application.
 - **hasOther**: `boolean` (default `false`) -- if `true`, allows the user to enter a custom "free text" value instead of one of the pre-defined options.
@@ -285,7 +285,7 @@ _Multi-choice question, with one allowed selection, displayed as labelled radio 
 - **description**: `string` -- as above [Optional]
 - **options**: `array[string | object]` -- as above (in [Drop-down](#dropdown))
 - **default**: `string`/`number` -- the value initially selected before user input. If `number`, refers to the index of the options array. If not provided, no options will be pre-selected.
-- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
+- **persistUserInput**: `boolean` -- if `false`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`true`), the default will only be used if there is no response yet. [Optional; default `false`]
 - **optionsDisplayProperty**: -- as above (in Drop-down)
 - **layout**: `string` -- if "inline", displays radio buttons horizontally, rather than stacked vertically (default)
 - **hasOther**: `boolean` (default `false`) -- if `true`, displays an additional "Other" option with a free text field for inputting additional user-defined option.
@@ -447,7 +447,7 @@ _Allows user to build a list of items, such as an **Ingredients List**_
 - **label**: `string` -- as above
 - **description**: `string` -- as above [Optional]
 - **default** `ResponseList` -- default value for the list. Must be in the format of the `list` parameter from the Response object (i.e. an array of objects)
-- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
+- **persistUserInput**: `boolean` -- if `false`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`true`), the default will only be used if there is no response yet. [Optional; default `false`]
 - **createModalButtonText** `string` -- text to display on the button to launch the new item interface (modal) (default: "Add item")
 - **addButtonText** `string` -- text to display on the button to add a new item from the item editing modal (default: "Add")
 - **updateButtonText** `string` -- text to display on the button to update an existing item from the item editing modal (default: "Update")
@@ -562,7 +562,7 @@ Once selected, items are displayed in a "card" view:
   }
   ```
 - **default** `ResponseSelection` / `ResponseSelection[]` -- default value for the selection(s). Must be in the format of the `selection` parameter from the Response object (i.e. an array of objects), or just a single object if not multi-select.
-- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
+- **persistUserInput**: `boolean` -- if `false`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`true`), the default will only be used if there is no response yet. [Optional; default `false`]
 - **icon**: `string` -- the name of the icon shown in the search box, from Semantic-UI icons. (default: "search" : 🔍 )
 - **multiSelect**: `boolean` -- whether or not the user can select multiple items for their response (default: `false`)
 - **minCharacters**: `number` -- the minimum number of characters the user must type before the search query executes (default: 1). This is useful in situations where need the user to look up a specific item without being able to freely browse through the entire results list. For example, to look up organisation in our system using "registration" code, we set `minCharacters = 6`, so the user will need to know an exact code rather than being able to try characters one at a time.
@@ -612,7 +612,7 @@ Uses [React Semantic-UI Datepickers](https://www.npmjs.com/package/react-semanti
 - **label**: `string` -- as above
 - **description**: `string` -- as above [Optional]
 - **default**: `(ISO) string` -- a pre-selected date [Optional]
-- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
+- **persistUserInput**: `boolean` -- if `false`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`true`), the default will only be used if there is no response yet. [Optional; default `false`]
 - **allowRange**: `boolean` -- if `true`, input is expected to be a date _range_ (a start and end date). Default: `false` (i.e. can only enter single date)
 - **minDate**/**maxDate**: `(ISO) string` -- specifies how far into the future or past the selector can go
 - **minAge**/**maxAge**: `(ISO) string` -- same as above, but a number (in years) relative to the _current_ date. For example, if an applicant was required to be over 18 years old, you'd set `minAge` to `18`.
@@ -649,7 +649,7 @@ _Input for numeric fields_
 
 - **label** / **description** / **placeholder** / **maxWidth**: `string` -- as above
 - **default**: `string`/`number` -- default value 
-- **replaceResponseOnDefaultChange**: `boolean` -- if `true`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`false`), the default will only be used if there is no response yet. [Optional; default `true`]
+- **persistUserInput**: `boolean` -- if `false`, when the `default` value changes, the current response will be replaced by the new default. Otherwise (`true`), the default will only be used if there is no response yet. [Optional; default `false`]
 - **type** -- `enum` -- either "integer" or "float" (default: "integer")
 - **simple** -- `boolean` (default: `true`) If `true`, the input field will always show only a non-formatted version of the number (i.e. "1000", not "1,000"), but it will have a "stepper" which can be clicked to increment the number up and down.
 - **minValue** -- minimum allowed value (default: 0)

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -23,6 +23,8 @@ import getServerUrl from '../utils/helpers/endpoints/endpointUrlBuilder'
 
 const graphQLEndpoint = getServerUrl('graphQL')
 
+export const DEFAULT_LOADING_VALUE = 'Loading...'
+
 const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) => {
   const { strings } = useLanguageProvider()
   const calculateValidationState = useCalculateValidationState()
@@ -275,7 +277,7 @@ export const buildParameters = (
     if (internalParameters.includes(key)) simpleParameters[key] = value
     else if (isEvaluationExpression(value)) {
       parameterExpressions[key] = value
-      simpleParameters[key] = parameterLoadingValues?.[key] ?? 'Loading...'
+      simpleParameters[key] = parameterLoadingValues?.[key] ?? DEFAULT_LOADING_VALUE
     } else simpleParameters[key] = value
   }
   return [simpleParameters, parameterExpressions]

--- a/src/formElementPlugins/datePicker/pluginConfig.json
+++ b/src/formElementPlugins/datePicker/pluginConfig.json
@@ -6,8 +6,7 @@
     "label": "Loading...",
     "description": "",
     "minAge": -1000,
-    "maxAge": 1000,
-    "default": ""
+    "maxAge": 1000
   },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"

--- a/src/formElementPlugins/datePicker/src/ApplicationView.tsx
+++ b/src/formElementPlugins/datePicker/src/ApplicationView.tsx
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon'
 import 'react-semantic-ui-datepickers/dist/react-semantic-ui-datepickers.css'
 import { useLanguageProvider } from '../../../contexts/Localisation'
 import { LocaleOptions } from 'react-semantic-ui-datepickers/dist/types'
+import useDefault from '../../useDefault'
 
 // Stored response date format
 interface DateSaved {
@@ -42,8 +43,9 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const {
     label,
     description,
-    default: defaultDate,
-    allowRange = Array.isArray(defaultDate),
+    default: defaultValue,
+    replaceResponseOnDefaultChange,
+    allowRange = Array.isArray(defaultValue),
     locale = selectedLanguage.locale,
     displayFormat = 'short',
     entryFormat = 'YYYY-MM-DD',
@@ -61,24 +63,20 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     [minDate, maxDate, minAge, maxAge]
   )
 
-  // Set "default" date if present
-  useEffect(() => {
-    if (!selectedDate && defaultDate) {
+  useDefault({
+    defaultValue,
+    currentResponse,
+    replaceResponseOnDefaultChange,
+    onChange: (defaultDate) => {
       const date = dateFromDefault(defaultDate)
-      onSave({ text: toDisplayString(date, locale, displayFormat), date })
-      setSelectedDate(date)
-    }
-  }, [defaultDate])
+      handleSelect(date)
+    },
+  })
 
-  useEffect(() => {
-    onSave({
-      text: toDisplayString(selectedDate, locale, displayFormat),
-      date: toDateSaved(selectedDate),
-    })
-  }, [selectedDate])
-
-  const handleSelect = (event: any, data: any) => {
-    setSelectedDate(data.value)
+  const handleSelect = (date?: SelectedDateRange) => {
+    if (date === undefined) return
+    setSelectedDate(date)
+    onSave({ text: toDisplayString(date, locale, displayFormat), date: toDateSaved(date) })
   }
 
   return (
@@ -91,7 +89,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       <Markdown text={description} />
       <SemanticDatepicker
         locale={locale}
-        onChange={handleSelect}
+        onChange={(_, data) => handleSelect(data.value)}
         type={allowRange ? 'range' : 'basic'}
         value={selectedDate}
         format={entryFormat}

--- a/src/formElementPlugins/datePicker/src/ApplicationView.tsx
+++ b/src/formElementPlugins/datePicker/src/ApplicationView.tsx
@@ -44,7 +44,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     label,
     description,
     default: defaultValue,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
     allowRange = Array.isArray(defaultValue),
     locale = selectedLanguage.locale,
     displayFormat = 'short',
@@ -66,7 +66,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   useDefault({
     defaultValue,
     currentResponse,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
     onChange: (defaultDate) => {
       const date = dateFromDefault(defaultDate)
       handleSelect(date)

--- a/src/formElementPlugins/datePicker/src/ApplicationView.tsx
+++ b/src/formElementPlugins/datePicker/src/ApplicationView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react'
+import React, { useState, useMemo } from 'react'
 import { ApplicationViewProps } from '../../types'
 import SemanticDatepicker from 'react-semantic-ui-datepickers'
 import { DateTime } from 'luxon'

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -29,7 +29,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     optionsDisplayProperty,
     hasOther,
     default: defaultValue,
-    shouldUpdateIfFilled,
+    replaceResponseOnDefaultChange,
   } = parameters as {
     label?: string
     description?: string
@@ -37,7 +37,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     search?: boolean
     hasOther?: boolean
     default?: any
-    shouldUpdateIfFilled?: boolean
+    replaceResponseOnDefaultChange?: boolean
   } & (ObjectOptions | StringOptions)
 
   const [selectedIndex, setSelectedIndex] = useState<number>()
@@ -48,7 +48,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   useDefault({
     defaultValue,
     currentResponse,
-    shouldUpdateIfFilled,
+    replaceResponseOnDefaultChange,
     additionalDependencies: [options],
     onChange: (defaultOption: any) => {
       const optionIndex = getDefaultIndex(defaultOption, options)

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -46,6 +46,22 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const { isEditable } = element
 
   useEffect(() => {
+    if (options[0] === 'Loading...') return
+
+    // For when the "text" value is pre-filled by an external source (i.e.
+    // listBuilder wrapper), we need to re-create the other response components
+    if (currentResponse?.text && currentResponse?.selection === undefined) {
+      const optionIndex = getDefaultIndex(currentResponse.text, options)
+      onSave({
+        text: options[optionIndex],
+        selection: options[optionIndex],
+        optionIndex,
+        isCustomOption: false,
+      })
+      setSelectedIndex(optionIndex)
+      return
+    }
+
     // This ensures that, if a default is specified, it gets saved on first load
     if (!currentResponse?.text && defaultOption !== undefined) {
       const optionIndex = getDefaultIndex(defaultOption, options)

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -45,7 +45,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   )
   const [addedOption, setAddedOption] = useState<string | null>(null)
 
-  const { isEditable } = element
+  const { isEditable, isRequired } = element
 
   useEffect(() => {
     // This deals with the case when a default response has been externally set
@@ -123,7 +123,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         fluid
         // multiple
         selection
-        clearable
+        clearable={isEditable && !isRequired}
         disabled={!isEditable}
         search={search || hasOther}
         allowAdditions={hasOther}

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -66,7 +66,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       const { optionIndex } = currentResponse
       setSelectedIndex(optionIndex)
     }
-  }, [])
+  }, [defaultOption, options])
 
   const addItemHandler = (text: string) => {
     setAddedOption(text)
@@ -123,6 +123,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         // multiple
         selection
         clearable
+        disabled={!isEditable}
         search={search || hasOther}
         allowAdditions={hasOther}
         additionLabel={strings.ADD_CUSTOM_OPTION_LABEL}

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Dropdown, Label } from 'semantic-ui-react'
 import { ResponseFull } from '../../../utils/types'
 import { ApplicationViewProps } from '../../types'
@@ -40,10 +40,22 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     replaceResponseOnDefaultChange?: boolean
   } & (ObjectOptions | StringOptions)
 
-  const [selectedIndex, setSelectedIndex] = useState<number>()
+  const [selectedIndex, setSelectedIndex] = useState<number | undefined>(
+    currentResponse?.optionIndex ?? undefined
+  )
   const [addedOption, setAddedOption] = useState<string | null>(null)
 
   const { isEditable } = element
+
+  useEffect(() => {
+    // This deals with the case when a default response has been externally set
+    // (e.g. by a ListBuilder) and only a selection (with no index) has been
+    // provided.
+    if (options[0] === 'Loading...') return
+    if (currentResponse?.selection || currentResponse?.optionIndex === undefined) {
+      setSelectedIndex(getDefaultIndex(currentResponse?.selection, options))
+    }
+  }, [options])
 
   useDefault({
     defaultValue,

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -36,7 +36,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     placeholder?: string
     search?: boolean
     hasOther?: boolean
-    default?: any
+    default?: string | number
     replaceResponseOnDefaultChange?: boolean
   } & (ObjectOptions | StringOptions)
 

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -29,7 +29,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     optionsDisplayProperty,
     hasOther,
     default: defaultValue,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
   } = parameters as {
     label?: string
     description?: string
@@ -37,7 +37,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     search?: boolean
     hasOther?: boolean
     default?: string | number
-    replaceResponseOnDefaultChange?: boolean
+    persistUserInput?: boolean
   } & (ObjectOptions | StringOptions)
 
   const [selectedIndex, setSelectedIndex] = useState<number | undefined>(
@@ -60,7 +60,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   useDefault({
     defaultValue,
     currentResponse,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
     additionalDependencies: [options],
     onChange: (defaultOption: any) => {
       const optionIndex = getDefaultIndex(defaultOption, options)

--- a/src/formElementPlugins/listBuilder/pluginConfig.json
+++ b/src/formElementPlugins/listBuilder/pluginConfig.json
@@ -4,7 +4,8 @@
   "displayName": "List Builder",
   "parameterLoadingValues": {
     "label": "Loading...",
-    "description": ""
+    "description": "",
+    "default": ["Loading"]
   },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"

--- a/src/formElementPlugins/listBuilder/pluginConfig.json
+++ b/src/formElementPlugins/listBuilder/pluginConfig.json
@@ -4,8 +4,7 @@
   "displayName": "List Builder",
   "parameterLoadingValues": {
     "label": "Loading...",
-    "description": "",
-    "default": ["Loading"]
+    "description": ""
   },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -50,7 +50,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     displayFormat = getDefaultDisplayFormat(inputFields),
     displayType = DisplayType.CARDS,
     default: defaultValue,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
   } = parameters
   const {
     userState: { currentUser },
@@ -89,7 +89,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   useDefault({
     defaultValue,
     currentResponse,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
     onChange: (defaultList) => setListItems(defaultList ?? []),
   })
 

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -90,9 +90,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     defaultValue,
     currentResponse,
     replaceResponseOnDefaultChange,
-    onChange: (defaultList) => {
-      setListItems(defaultList)
-    },
+    onChange: (defaultList) => setListItems(defaultList),
   })
 
   useEffect(() => {

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -90,7 +90,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     defaultValue,
     currentResponse,
     replaceResponseOnDefaultChange,
-    onChange: (defaultList) => setListItems(defaultList),
+    onChange: (defaultList) => setListItems(defaultList ?? []),
   })
 
   useEffect(() => {

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -48,6 +48,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     inputFields,
     displayFormat = getDefaultDisplayFormat(inputFields),
     displayType = DisplayType.CARDS,
+    default: defaultList,
   } = parameters
   const {
     userState: { currentUser },
@@ -82,6 +83,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       setInputState((prevState) => ({ ...prevState, currentElementsState: elements }))
     )
   }, [inputState.currentResponses])
+
+  useEffect(() => {
+    if (!defaultList || defaultList[0] == 'Loading') return
+    if (listItems.length === 0) setListItems(defaultList)
+  }, [defaultList])
 
   useEffect(() => {
     onSave({

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -20,6 +20,7 @@ import {
 } from './displayComponents'
 import { useLanguageProvider } from '../../../contexts/Localisation'
 import { useUserState } from '../../../contexts/UserState'
+import useDefault from '../../useDefault'
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
@@ -48,7 +49,8 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     inputFields,
     displayFormat = getDefaultDisplayFormat(inputFields),
     displayType = DisplayType.CARDS,
-    default: defaultList,
+    default: defaultValue,
+    replaceResponseOnDefaultChange,
   } = parameters
   const {
     userState: { currentUser },
@@ -84,10 +86,14 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     )
   }, [inputState.currentResponses])
 
-  useEffect(() => {
-    if (!defaultList || defaultList[0] == 'Loading') return
-    if (listItems.length === 0) setListItems(defaultList)
-  }, [defaultList])
+  useDefault({
+    defaultValue,
+    currentResponse,
+    replaceResponseOnDefaultChange,
+    onChange: (defaultList) => {
+      setListItems(defaultList)
+    },
+  })
 
   useEffect(() => {
     onSave({

--- a/src/formElementPlugins/longText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/longText/src/ApplicationView.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { Form } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
+import useDefault from '../../useDefault'
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
@@ -13,20 +14,28 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   Markdown,
 }) => {
   const [value, setValue] = useState<string | null | undefined>(currentResponse?.text)
-  const [hasEdited, setHasEdited] = useState(
-    currentResponse?.text !== null && currentResponse?.text !== parameters?.default
-  )
-
-  const { label, description, placeholder, lines, maxLength, default: defaultText } = parameters
 
   const { isEditable } = element
 
-  useEffect(() => {
-    if (defaultText && (!hasEdited || !value)) {
-      onSave({ text: defaultText })
+  const {
+    label,
+    description,
+    placeholder,
+    lines,
+    maxLength,
+    default: defaultValue,
+    shouldUpdateIfFilled,
+  } = parameters
+
+  useDefault({
+    defaultValue,
+    currentResponse,
+    shouldUpdateIfFilled,
+    onChange: (defaultText: string) => {
       setValue(defaultText)
-    } else onUpdate(value)
-  }, [defaultText])
+      onSave({ text: defaultText })
+    },
+  })
 
   function handleChange(e: any) {
     let text = e.target.value
@@ -35,7 +44,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     }
     onUpdate(text)
     setValue(text)
-    setHasEdited(true)
   }
 
   function handleLoseFocus(e: any) {

--- a/src/formElementPlugins/longText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/longText/src/ApplicationView.tsx
@@ -24,13 +24,13 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     lines,
     maxLength,
     default: defaultValue,
-    shouldUpdateIfFilled,
+    replaceResponseOnDefaultChange,
   } = parameters
 
   useDefault({
     defaultValue,
     currentResponse,
-    shouldUpdateIfFilled,
+    replaceResponseOnDefaultChange,
     onChange: (defaultText: string) => {
       setValue(defaultText)
       onSave({ text: defaultText })

--- a/src/formElementPlugins/longText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/longText/src/ApplicationView.tsx
@@ -24,13 +24,13 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     lines,
     maxLength,
     default: defaultValue,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
   } = parameters
 
   useDefault({
     defaultValue,
     currentResponse,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
     onChange: (defaultText: string) => {
       setValue(defaultText)
       onSave({ text: defaultText })

--- a/src/formElementPlugins/number/pluginConfig.json
+++ b/src/formElementPlugins/number/pluginConfig.json
@@ -4,7 +4,6 @@
   "displayName": "Number Input",
   "parameterLoadingValues": {
     "label": "Loading...",
-    "default": "",
     "description": "",
     "maxWidth": null,
     "type": "float",

--- a/src/formElementPlugins/number/src/ApplicationView.tsx
+++ b/src/formElementPlugins/number/src/ApplicationView.tsx
@@ -41,7 +41,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     suffixPlural = suffix,
     maxSignificantDigits,
     default: defaultValue,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
   } = parameters
   const [textValue, setTextValue] = useState<string | null | undefined>(currentResponse?.text)
   const [internalValidation, setInternalValidation] = useState(validationState)
@@ -56,7 +56,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   useDefault({
     defaultValue,
     currentResponse,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
     onChange: (defaultNumber) => {
       setTextValue(String(defaultNumber))
       handleLoseFocus(String(defaultNumber))

--- a/src/formElementPlugins/number/src/ApplicationView.tsx
+++ b/src/formElementPlugins/number/src/ApplicationView.tsx
@@ -53,7 +53,12 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   useEffect(() => {
     // Ensures defaultValue is saved on first load
-    if (!currentResponse?.text && defaultValue !== undefined) {
+    if (
+      !currentResponse?.text &&
+      defaultValue !== undefined &&
+      defaultValue !== null &&
+      defaultValue !== ''
+    ) {
       const { number, formattedNumber, fullText } = parseInput(
         String(defaultValue),
         numberFormatter,
@@ -68,7 +73,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         onSave({ text: fullText, number, type, currency, locale, prefix, suffix, suffixPlural })
       setTextValue(formattedNumber)
     }
-  }, [])
+  }, [defaultValue])
 
   useEffect(() => {
     if (!textValue) return

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Radio, Form, Input, Label, CheckboxProps } from 'semantic-ui-react'
+import { Radio, Form, Input, Label } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
 import { useLanguageProvider } from '../../../contexts/Localisation'
 import useDefault from '../../useDefault'
@@ -56,12 +56,12 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     additionalDependencies: [options],
   })
 
-  function handleChange(optionIndex: number, additionalText?: string) {
+  function handleChange(optionIndex: number, additionalText: string | undefined = otherText) {
     setSelectedIndex(optionIndex)
     onSave({
       text:
         hasOther && optionIndex === allOptions.length - 1
-          ? additionalText ?? otherText ?? ''
+          ? additionalText ?? ''
           : optionsDisplayProperty
           ? allOptions[optionIndex][optionsDisplayProperty]
           : allOptions[optionIndex],

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -21,7 +21,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     description,
     options,
     default: defaultValue,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
     optionsDisplayProperty,
     hasOther,
     otherPlaceholder,
@@ -46,7 +46,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   useDefault({
     defaultValue,
     currentResponse,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
     onChange: (defaultOption) => {
       const optionIndex = getDefaultIndex(defaultOption, options)
       if (optionIndex >= 0) handleChange(optionIndex)

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react'
-import { Radio, Form, Input, Label } from 'semantic-ui-react'
+import React, { useState } from 'react'
+import { Radio, Form, Input, Label, CheckboxProps } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
 import { useLanguageProvider } from '../../../contexts/Localisation'
+import useDefault from '../../useDefault'
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
@@ -19,7 +20,8 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     label,
     description,
     options,
-    default: defaultOption,
+    default: defaultValue,
+    replaceResponseOnDefaultChange,
     optionsDisplayProperty,
     hasOther,
     otherPlaceholder,
@@ -39,32 +41,27 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       : undefined
   )
 
-  useEffect(() => {
-    // This ensures that, if a default is specified, it gets saved on first load
-    if (!currentResponse?.text && defaultOption !== undefined) {
+  useDefault({
+    defaultValue,
+    currentResponse,
+    replaceResponseOnDefaultChange,
+    onChange: (defaultOption) => {
       const optionIndex = getDefaultIndex(defaultOption, options)
-      onSave({
-        text: optionsDisplayProperty
-          ? allOptions[optionIndex][optionsDisplayProperty]
-          : allOptions[optionIndex],
-        selection: allOptions[optionIndex],
-        optionIndex,
-      })
-      setSelectedIndex(optionIndex)
-    }
-    if (currentResponse?.text) {
-      const { optionIndex } = currentResponse
-      setSelectedIndex(optionIndex)
-    }
-  }, [])
+      if (optionIndex >= 0) handleChange(optionIndex)
+      else {
+        if (!hasOther) return
+        handleChange(allOptions.length - 1, defaultOption)
+      }
+    },
+    additionalDependencies: [options],
+  })
 
-  function handleChange(e: any, data: any) {
-    const { index: optionIndex } = data
+  function handleChange(optionIndex: number, additionalText?: string) {
     setSelectedIndex(optionIndex)
     onSave({
       text:
         hasOther && optionIndex === allOptions.length - 1
-          ? otherText || ''
+          ? additionalText ?? otherText ?? ''
           : optionsDisplayProperty
           ? allOptions[optionIndex][optionsDisplayProperty]
           : allOptions[optionIndex],
@@ -72,13 +69,14 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       optionIndex,
       other: hasOther && optionIndex === allOptions.length - 1,
     })
+    if (additionalText) setOtherText(additionalText)
   }
 
-  function handleOtherChange(e: any, { value }: any) {
+  function handleOtherChange(value: string) {
     setOtherText(value)
   }
 
-  function handleOtherLoseFocus(e: any) {
+  function handleOtherLoseFocus(_: any) {
     onSave({
       text: otherText,
       selection: allOptions[allOptions.length - 1],
@@ -126,7 +124,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
               name={`${code}_radio_${index}`} // This is GROUP name
               value={selectedIndex}
               checked={index === selectedIndex}
-              onChange={handleChange}
+              onChange={(_, { index }) => handleChange(index)}
               index={index}
             />
             {showOther && (
@@ -134,7 +132,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
                 placeholder={otherPlaceholder}
                 size="small"
                 disabled={selectedIndex !== allOptions.length - 1}
-                onChange={handleOtherChange}
+                onChange={(_, { value }) => handleOtherChange(value)}
                 onBlur={handleOtherLoseFocus}
                 value={otherText}
               />

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -30,7 +30,9 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   const { code, isEditable } = element
 
-  const [selectedIndex, setSelectedIndex] = useState<number>()
+  const [selectedIndex, setSelectedIndex] = useState<number | undefined>(
+    currentResponse?.optionIndex
+  )
 
   const allOptions = [...options]
   if (hasOther) allOptions.push(strings.OTHER)

--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -119,6 +119,10 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   }
 
   const handleChange = (e: any) => {
+    // With "Input" style, we clear the selection if the user changes the input
+    // string (otherwise it remains even though it's not displayed anywhere)
+    if (displayType === 'input') setSelection([])
+
     const text = e.target.value
     setSearchText(text)
     if (text.length < minCharacters) return
@@ -136,6 +140,13 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         ? substituteValues(displayFormat.title ?? displayFormat.description, selectedResult)
         : ''
     )
+  }
+
+  const handleFocus = (e: any) => {
+    // This makes the component perform a new search when re-focusing (if no
+    // selection already), as changes in other elements may have changed some of
+    // the dynamic parameters in this element
+    if (searchText.length > 0 && selection.length === 0) handleChange(e)
   }
 
   const deleteItem = async (index: number) => {
@@ -186,6 +197,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         <Search
           value={searchText}
           loading={loading}
+          onFocus={handleFocus}
           onSearchChange={handleChange}
           onResultSelect={handleSelect}
           minCharacters={minCharacters}

--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -44,7 +44,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     textFormat,
     displayType = 'card',
     default: defaultValue,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
   } = parameters
 
   const {
@@ -71,7 +71,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   useDefault({
     defaultValue,
     currentResponse,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
     onChange: (defaultSelection) => {
       setSelection(Array.isArray(defaultSelection) ? defaultSelection : [defaultSelection])
       setSearchText(

--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -10,6 +10,7 @@ import evaluateExpression from '@openmsupply/expression-evaluator'
 import config from '../../../config'
 import useDebounce from './useDebounce'
 import './styles.css'
+import useDefault from '../../useDefault'
 
 interface DisplayFormat {
   title?: string
@@ -42,7 +43,8 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     resultFormat = displayFormat,
     textFormat,
     displayType = 'card',
-    defaultSelection,
+    default: defaultValue,
+    replaceResponseOnDefaultChange,
   } = parameters
 
   const {
@@ -66,17 +68,26 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   const [debounceOutput, setDebounceInput] = useDebounce<string>('', DEBOUNCE_TIMEOUT)
 
+  useDefault({
+    defaultValue,
+    currentResponse,
+    replaceResponseOnDefaultChange,
+    onChange: (defaultSelection) => {
+      setSelection(Array.isArray(defaultSelection) ? defaultSelection : [defaultSelection])
+      setSearchText(
+        displayType === 'input'
+          ? substituteValues(displayFormat.title ?? displayFormat.description, defaultSelection)
+          : ''
+      )
+    },
+  })
+
   useEffect(() => {
     onSave({
       text: getTextFormat(textFormat, selection),
       selection,
     })
   }, [selection])
-
-  useEffect(() => {
-    if (!defaultSelection) return
-    if (selection.length === 0) setSelection([defaultSelection])
-  }, [defaultSelection])
 
   useEffect(() => {
     if (!debounceOutput) return

--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -42,6 +42,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     resultFormat = displayFormat,
     textFormat,
     displayType = 'card',
+    defaultSelection,
   } = parameters
 
   const {
@@ -60,7 +61,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   )
   const [loading, setLoading] = useState(false)
   const [results, setResults] = useState<any[]>([])
-  const [selection, setSelection] = useState<any[]>(currentResponse?.selection || [])
+  const [selection, setSelection] = useState<any[]>(currentResponse?.selection ?? [])
   const { isEditable } = element
 
   const [debounceOutput, setDebounceInput] = useDebounce<string>('', DEBOUNCE_TIMEOUT)
@@ -68,9 +69,14 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   useEffect(() => {
     onSave({
       text: getTextFormat(textFormat, selection),
-      selection: selection,
+      selection,
     })
   }, [selection])
+
+  useEffect(() => {
+    if (!defaultSelection) return
+    if (selection.length === 0) setSelection([defaultSelection])
+  }, [defaultSelection])
 
   useEffect(() => {
     if (!debounceOutput) return

--- a/src/formElementPlugins/shortText/pluginConfig.json
+++ b/src/formElementPlugins/shortText/pluginConfig.json
@@ -4,7 +4,6 @@
   "displayName": "Basic Text Input",
   "parameterLoadingValues": {
     "label": "Loading...",
-    "default": "",
     "description": ""
   },
   "//": "categories types: 'Input'|'Informative'",

--- a/src/formElementPlugins/shortText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/shortText/src/ApplicationView.tsx
@@ -24,13 +24,13 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     maxWidth,
     maxLength = Infinity,
     default: defaultValue,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
   } = parameters
 
   useDefault({
     defaultValue,
     currentResponse,
-    replaceResponseOnDefaultChange,
+    persistUserInput,
     onChange: (defaultText: string) => {
       setValue(defaultText)
       onSave({ text: defaultText })

--- a/src/formElementPlugins/shortText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/shortText/src/ApplicationView.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { Form } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
+import useDefault from '../../useDefault'
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
@@ -13,9 +14,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   Markdown,
 }) => {
   const [value, setValue] = useState<string | null | undefined>(currentResponse?.text)
-  const [hasEdited, setHasEdited] = useState(
-    currentResponse?.text !== null && currentResponse?.text !== parameters?.default
-  )
+
   const { isEditable } = element
   const {
     placeholder,
@@ -24,15 +23,19 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     description,
     maxWidth,
     maxLength = Infinity,
-    default: defaultText,
+    default: defaultValue,
+    shouldUpdateIfFilled,
   } = parameters
 
-  useEffect(() => {
-    if (defaultText && (!hasEdited || !value)) {
-      onSave({ text: defaultText })
+  useDefault({
+    defaultValue,
+    currentResponse,
+    shouldUpdateIfFilled,
+    onChange: (defaultText: string) => {
       setValue(defaultText)
-    } else onUpdate(value)
-  }, [defaultText])
+      onSave({ text: defaultText })
+    },
+  })
 
   function handleChange(e: any) {
     let text = e.target.value
@@ -41,7 +44,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     }
     onUpdate(text)
     setValue(text)
-    setHasEdited(true)
   }
 
   function handleLoseFocus(e: any) {

--- a/src/formElementPlugins/shortText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/shortText/src/ApplicationView.tsx
@@ -24,13 +24,13 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     maxWidth,
     maxLength = Infinity,
     default: defaultValue,
-    shouldUpdateIfFilled,
+    replaceResponseOnDefaultChange,
   } = parameters
 
   useDefault({
     defaultValue,
     currentResponse,
-    shouldUpdateIfFilled,
+    replaceResponseOnDefaultChange,
     onChange: (defaultText: string) => {
       setValue(defaultText)
       onSave({ text: defaultText })

--- a/src/formElementPlugins/types.ts
+++ b/src/formElementPlugins/types.ts
@@ -30,8 +30,8 @@ type ValidationState = {
 }
 
 interface ApplicationViewProps extends ApplicationViewWrapperProps {
-  onUpdate: Function
-  onSave: Function
+  onUpdate: (value: string) => void
+  onSave: (value: any) => void
   initialValue: any
   setIsActive: () => void
   validationState: ValidationState

--- a/src/formElementPlugins/useDefault.ts
+++ b/src/formElementPlugins/useDefault.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react'
+import { ResponseFull } from '../utils/types'
+import { DEFAULT_LOADING_VALUE } from './ApplicationViewWrapper'
+
+interface UseDefaultProps {
+  defaultValue: any
+  currentResponse: ResponseFull | null
+  loadingValue?: string | null
+  shouldUpdateIfFilled?: boolean
+  onChange: (value: any) => void
+  additionalDependencies?: any[]
+}
+
+const useDefault = ({
+  defaultValue,
+  currentResponse,
+  loadingValue = DEFAULT_LOADING_VALUE,
+  shouldUpdateIfFilled = true,
+  onChange,
+  additionalDependencies = [],
+}: UseDefaultProps) => {
+  useEffect(() => {
+    if (defaultValue === loadingValue || defaultValue === null) return
+
+    if (shouldUpdateIfFilled || !currentResponse?.text) {
+      onChange(defaultValue)
+    }
+  }, [defaultValue, ...additionalDependencies])
+}
+
+export default useDefault

--- a/src/formElementPlugins/useDefault.ts
+++ b/src/formElementPlugins/useDefault.ts
@@ -6,7 +6,7 @@ interface UseDefaultProps {
   defaultValue: any
   currentResponse: ResponseFull | null
   loadingValue?: string | null
-  replaceResponseOnDefaultChange?: boolean
+  persistUserInput?: boolean
   onChange: (value: any) => void
   additionalDependencies?: any[]
 }
@@ -15,14 +15,14 @@ const useDefault = ({
   defaultValue,
   currentResponse,
   loadingValue = DEFAULT_LOADING_VALUE,
-  replaceResponseOnDefaultChange = true,
+  persistUserInput = false,
   onChange,
   additionalDependencies = [],
 }: UseDefaultProps) => {
   useEffect(() => {
     if (defaultValue === loadingValue || defaultValue === undefined) return
 
-    if (replaceResponseOnDefaultChange || !currentResponse?.text) onChange(defaultValue)
+    if (!persistUserInput || !currentResponse?.text) onChange(defaultValue)
   }, [defaultValue, ...additionalDependencies])
 }
 

--- a/src/formElementPlugins/useDefault.ts
+++ b/src/formElementPlugins/useDefault.ts
@@ -20,7 +20,7 @@ const useDefault = ({
   additionalDependencies = [],
 }: UseDefaultProps) => {
   useEffect(() => {
-    if (defaultValue === loadingValue || defaultValue === null) return
+    if (defaultValue === loadingValue || !defaultValue) return
 
     if (replaceResponseOnDefaultChange || !currentResponse?.text) onChange(defaultValue)
   }, [defaultValue, ...additionalDependencies])

--- a/src/formElementPlugins/useDefault.ts
+++ b/src/formElementPlugins/useDefault.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import { ResponseFull } from '../utils/types'
 import { DEFAULT_LOADING_VALUE } from './ApplicationViewWrapper'
 
@@ -6,7 +6,7 @@ interface UseDefaultProps {
   defaultValue: any
   currentResponse: ResponseFull | null
   loadingValue?: string | null
-  shouldUpdateIfFilled?: boolean
+  replaceResponseOnDefaultChange?: boolean
   onChange: (value: any) => void
   additionalDependencies?: any[]
 }
@@ -15,16 +15,14 @@ const useDefault = ({
   defaultValue,
   currentResponse,
   loadingValue = DEFAULT_LOADING_VALUE,
-  shouldUpdateIfFilled = true,
+  replaceResponseOnDefaultChange = true,
   onChange,
   additionalDependencies = [],
 }: UseDefaultProps) => {
   useEffect(() => {
     if (defaultValue === loadingValue || defaultValue === null) return
 
-    if (shouldUpdateIfFilled || !currentResponse?.text) {
-      onChange(defaultValue)
-    }
+    if (replaceResponseOnDefaultChange || !currentResponse?.text) onChange(defaultValue)
   }, [defaultValue, ...additionalDependencies])
 }
 

--- a/src/formElementPlugins/useDefault.ts
+++ b/src/formElementPlugins/useDefault.ts
@@ -20,7 +20,7 @@ const useDefault = ({
   additionalDependencies = [],
 }: UseDefaultProps) => {
   useEffect(() => {
-    if (defaultValue === loadingValue || !defaultValue) return
+    if (defaultValue === loadingValue || defaultValue === undefined) return
 
     if (replaceResponseOnDefaultChange || !currentResponse?.text) onChange(defaultValue)
   }, [defaultValue, ...additionalDependencies])

--- a/src/utils/helpers/utilityFunctions.ts
+++ b/src/utils/helpers/utilityFunctions.ts
@@ -29,7 +29,8 @@ export const substituteValues = (
   // Custom replacement function for regex replace
   const getObjectProperty = (_: string, __: string, property: string) => {
     if (typeof data !== 'object') return data
-    return extractObjectProperty(data, property, `Can't find property: ${property}`)
+    const value = extractObjectProperty(data, property, `Can't find property: ${property}`)
+    return value ?? ''
   }
 
   // Match ${...} using regex and replace ... with property from object


### PR DESCRIPTION
Fix #1469 #1474 

~~Bit more than I'd hoped to get this working, and I'm still not 100% sold on it. I'd like to do a more robust overhaul of the plugin default handling (to make them all use a common mechanism), but that'll have to wait for now.~~

Ignore the above, I've managed to squeeze in #1474 which makes this a lot nicer and consistent (and easier to read!) There is a new, very simple hook, `useDefault` that the form elements all share, which handles the logic of checking and updating responses based on changing default values. (I've done for all elements that could possible require a default, except for "Checkboxes", since the checkboxes can be defined with a "selected" state in them already. (Admittedly, this would be a bit tricky to make dynamic, but we can add that when we need it.)

To test it out, use the snapshot `/demo_fiji/AAA_Fiji_Provisional_registration.zip` in the templates repo and look at the "Provisional Medicinal Product Registration" template. Fill in the "Search for existing product" with a valid product ID or name and notice the other fields automatically pre-fill (including the ones on page 2). Note what happens when you change the Product or the Authority (New Zealand / Australia / Other)

~~Please note, however, that they'll only pre-fill on the *first* selection -- if you change the product id again, they won't change again. If this functionality is required, it'll be a decent amount more work, so I'll need to check with @jagoje if it's needed.~~ (Done 🥳)

Currently there's only 5 products in the product lookup table, as I had to create them manually for this purpose, so the valid IDs are:

- 45077
- 278728
- 172845
- 309794
- 14937

**Update**: there's one case I haven't accounted for -- when the "default" source is reset to empty value/null, the dependent form elements *don't* get reset, because we're treating a `falsy` default as not having one, so nothing gets updated. Will have to have a think about how to handle this without messing up other cases (as normally empty default *does* mean there isn't one). Might have to explicitly distinguish between `null` and empty string, perhaps?

**Update 2**: I've kind of handled the above problem in that a default value of `null` will be recognised as a valid default, which can be used to reset certain elements. It won't work for all (as `null` is not a valid default for some elements), and it won't recognise a change if a different condition also outputs `null`, but it'll do for the current use case.