### PR TITLE
#1007B Template export fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-web-app",
-  "version": "0.5.2",
+  "version": "0.5.3-0",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-web-app",
-  "version": "0.5.3-1",
+  "version": "0.5.3-2",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-web-app",
-  "version": "0.5.3-0",
+  "version": "0.5.3-1",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/src/containers/TemplateBuilder/Templates.tsx
+++ b/src/containers/TemplateBuilder/Templates.tsx
@@ -91,18 +91,12 @@ const ViewEditButton: React.FC<CellProps> = ({ template: { id } }) => {
 }
 
 const ExportButton: React.FC<CellProps> = ({ template: { code, version, id } }) => {
-  const downloadLinkRef = useRef<HTMLAnchorElement>(null)
   const { exportTemplate } = useOperationState()
   const snapshotName = `${code}-${version}`
   const JWT = localStorage.getItem(config.localStorageJWTKey)
 
   return (
     <div key="export">
-      <a
-        ref={downloadLinkRef}
-        href={getServerUrl('snapshot', { action: 'download', name: snapshotName })}
-        target="_blank"
-      ></a>
       <div
         className="clickable"
         onClick={async (e) => {
@@ -119,6 +113,12 @@ const ExportButton: React.FC<CellProps> = ({ template: { code, version, id } }) 
             a.href = window.URL.createObjectURL(data)
             a.download = `${snapshotName}.zip`
             a.click()
+            // Delete the snapshot cos we don't want snapshots page cluttered
+            // with individual templates
+            await fetch(getServerUrl('snapshot', { action: 'delete', name: snapshotName }), {
+              method: 'POST',
+              headers: { Authorization: `Bearer ${JWT}` },
+            })
           }
         }}
       >

--- a/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
+++ b/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
@@ -198,10 +198,6 @@ export const exportTemplate: TemplateOperationHelper = async (
     setErrorAndLoadingState
   )
 
-  // Delete the snapshot cos we don't want snapshots page cluttered with individual templates
-  // if (result)
-  //   safeFetch(getServerUrl('snapshot', { action: 'delete', name: snapshotName }), {}, () => {})
-
   return result
 }
 

--- a/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
+++ b/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
@@ -199,8 +199,8 @@ export const exportTemplate: TemplateOperationHelper = async (
   )
 
   // Delete the snapshot cos we don't want snapshots page cluttered with individual templates
-  if (result)
-    safeFetch(getServerUrl('snapshot', { action: 'delete', name: snapshotName }), {}, () => {})
+  // if (result)
+  //   safeFetch(getServerUrl('snapshot', { action: 'delete', name: snapshotName }), {}, () => {})
 
   return result
 }


### PR DESCRIPTION
Fix for back-end issue https://github.com/openmsupply/conforma-server/issues/1007 (PR: https://github.com/openmsupply/conforma-server/pull/1008)

Turns out that the snapshot file was sometimes being deleted *before* the download had completed, so I've moved the delete command to be part of the export/download button rather than part of the exportTemplate method.

There's not really much of a difference locally (only sometimes problematic), but it's apparent on the servers. 
I've added a pre-release build to https://conforma-demo.msupply.org:50000 so you can test it. Try exporting a template on that server compared with the other ones and notice how only this server reliably exports valid .zips.