### PR TITLE
#120T Fix for listBuilder LOQ bug

### DIFF
--- a/src/formElementPlugins/listBuilder/src/helpers.ts
+++ b/src/formElementPlugins/listBuilder/src/helpers.ts
@@ -45,9 +45,7 @@ export const anyInvalidItems = (currentInput: ListItem) =>
   Object.values(currentInput).some((response) => response.isValid === false)
 
 export const anyIncompleteItems = (currentInput: ListItem, inputFields: TemplateElement[]) =>
-  Object.values(currentInput).some(
-    (response, index) => inputFields[index]?.isRequired !== false && !response.value?.text
-  )
+  inputFields.some((field) => field?.isRequired !== false && !currentInput[field.code].value?.text)
 
 export const anyErrorItems = (currentInput: ListItem, inputFields: TemplateElement[]) =>
   anyInvalidItems(currentInput) || anyIncompleteItems(currentInput, inputFields)


### PR DESCRIPTION
Fix [#120T](https://github.com/openmsupply/conforma-templates/issues/120)

This was quite a subtle bug. The mistake was in "anyIncompleteItems" function, we were iterating over `Object.values(currentInput)` and matching it to `inputFields` with the iteration index. However, this is incorrect as the Object values array doesn't get arranged in the same order as the inputFields (since it's from unordered key-value pairs). So the bug was happening due to the "inputField" not being matched to its correct "currentInput.response"

So now I've changed it to iterate over the `inputFields` array instead and match to the correct "currentInput" by code lookup, which keeps them aligned correctly.

I'm surprised it's taking this long for this bug to become apparent!

Everything else (isRequired, etc) seems to be all working fine.