### PR TITLE
#1480 Multiple select for Drop-downs

### DIFF
--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -266,15 +266,30 @@ _Multi-choice question, with one allowed option, displayed as Drop-down list (Co
 - **search**: `boolean` (default: `false`) -- if `true`, the list of options can be searched and filtered by user
 - **optionsDisplayProperty**: If `options` (above) consists of an array of objects, this parameter specifies the field of each object to be displayed in the options list. For example, if `options` was a list of organisation objects (i.e. `{orgId, name, licenceNumber}`), you'd probably specify `name` as the `optionsDisplayProperty`. Note that even though one field is displayed to the user in the Dropdown list, the _entire_ selected object is saved as the selection. And if `optionsDisplayProperty` refers to a field that doesn't exist on the supplied object, the plugin will fail and show in error in the application.
 - **hasOther**: `boolean` (default `false`) -- if `true`, allows the user to enter a custom "free text" value instead of one of the pre-defined options.
+- **multiSelect**: `boolean` -- whether or not the user can select multiple items for their response (default: `false`)
+
+Note: if including an "Other" options, then options should only be an array of strings, or else you'll be mixing objects with strings, which will cause problems. In other words, you should never have both optionsDisplayProperty and hasOther defined in the same question element.
 
 #### Response type
 
+For single response configurations (`multiSelect = false`):
 ```
 {
   optionIndex: <integer> (index from the options array)
   text: <string> (actual text from options array)
   selection: <string | object> (entire object or string from the supplied options list)
   isCustomOption: <boolean> (if the selection is a custom "hasOther" option)
+}
+
+```
+
+For multiple response configurations (`multiSelect = true`):
+```
+{
+  optionIndex: array[<integer>] (indexes from the options array)
+  text: <string> (concatenation of selected text values from options array)
+  selection: array[<string | object>] (array of selected objects or strings from the supplied options list)
+  isCustomOption: <boolean> (if the selection includes a custom "hasOther" option)
 }
 
 ```


### PR DESCRIPTION
Fix #1480 

To see it implemented use the snapshot `dev/snapshots/core_templates_drop_down_multiselect.zip` from Templates repo and got to Section 1, Page 5 -- the first two elements on that page allow multiple selection -- one using objects in the background and one with strings. The string one (first one) also allows a "custom" option to be selected as well.

Be good to get this tested out in current snapshots too -- in particular, please ensure there are no regressions to existing behaviour!