### PR TITLE
#1026B Default filters for Data Views

### DIFF
--- a/src/containers/List/ListFilters/ListFilters.tsx
+++ b/src/containers/List/ListFilters/ListFilters.tsx
@@ -50,7 +50,7 @@ const ListFilters: React.FC<{
   // Add filters from URL to activeFilters, filters may not have criteria/options yet thus we have to use activeFilter state variable
   useEffect(() => {
     // Reset active filters if coming from Database menu selection
-    if (location?.state?.resetFilters) {
+    if (location?.state?.resetFilters && location.search === '') {
       setActiveFilters([])
       return
     }

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -57,7 +57,13 @@ const UserArea: React.FC = () => {
 }
 interface MainMenuBarProps {
   templates: TemplateInList[]
-  dataViews: { tableName: string; title: string; code: string; urlSlug: string }[]
+  dataViews: {
+    tableName: string
+    title: string
+    code: string
+    urlSlug: string
+    defaultFilter: string | null
+  }[]
   referenceDocs: {
     intReferenceDocs: { uniqueId: string; description: string }[]
     extReferenceDocs: { uniqueId: string; description: string }[]
@@ -98,10 +104,10 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({
     setDropDownsState((currState) => getNewDropdownsState(basepath, currState))
   }, [pathname])
 
-  const dataViewOptions = dataViews.map(({ code, urlSlug, title }) => ({
+  const dataViewOptions = dataViews.map(({ code, urlSlug, title, defaultFilter }) => ({
     key: code,
     text: title,
-    value: urlSlug,
+    value: urlSlug + (defaultFilter ? `?${defaultFilter}` : ''),
   }))
 
   const templateOptions = templates

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -687,6 +687,7 @@ export type DataViewsResponse = {
   title: string
   code: string
   urlSlug: string
+  defaultFilter: string | null
 }[]
 
 interface FormatOptions {


### PR DESCRIPTION
Front-end part of back-end PR: https://github.com/openmsupply/conforma-server/pull/1027

Just reads the "default_filter_string" provided by the data view API and appends it to the data view url.

To quickly test, load snapshot `/dev/snapshots/Fiji_2023_03_16_1827_default_filters.zip` from templates repo and check out the "Provisional Product Register" data view -- should load filtered to show only *active* products. 

Mess around with the "default_filter_string" value in the data_view definition and see what difference it makes.