### PR TITLE
#1486 Don't remove default filters on reset

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -1872,9 +1872,10 @@ a:hover {
     }
   }
 
-  .ui.label {
+  .result-count {
     flex-grow: 1;
     text-align: right;
+    font-size: @fontSmall;
   }
 
   // multiple is used to make sure filter menu stays open, but it adds extra

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -320,7 +320,7 @@ a:hover {
   }
   img {
     max-height: @headerHeight;
-    padding-top:8px;
+    padding-top: 8px;
     padding-bottom: 8px;
   }
 }
@@ -551,7 +551,7 @@ a:hover {
     bottom: 0;
     width: 100%;
   }
-  #preview-items{
+  #preview-items {
     display: flex;
     flex-direction: column;
     gap: 10px;
@@ -562,17 +562,19 @@ a:hover {
       background-color: @surfacesLight;
       width: 90%;
       border-radius: @borderRadius;
-      padding: 10px
+      padding: 10px;
     }
     .notification-preview {
       padding-top: 5px;
       padding-bottom: 5px;
-      h1, h2 {
+      h1,
+      h2 {
         font-size: 1.1em;
         font-weight: bold;
       }
-      h3, h4 {
-        font-size: 1.0em;
+      h3,
+      h4 {
+        font-size: 1em;
       }
       p {
         font-size: 0.95em;
@@ -587,7 +589,8 @@ a:hover {
       padding-left: 6px;
       gap: 10px;
     }
-    .error-item, .fallback-preview{
+    .error-item,
+    .fallback-preview {
       p {
         font-size: 1em;
       }
@@ -1803,11 +1806,12 @@ a:hover {
 
 #localisation-panel {
   .row-format {
-      gap: 20px;
-      width: 90%;
-      background-color: white;
-      margin-bottom: 5px;
-      padding: 10px; border-radius: 8px;    
+    gap: 20px;
+    width: 90%;
+    background-color: white;
+    margin-bottom: 5px;
+    padding: 10px;
+    border-radius: 8px;
   }
 }
 
@@ -1849,6 +1853,7 @@ a:hover {
 
   align-items: center;
   flex-wrap: wrap;
+  width: 100%;
 
   .list-filter-title {
     .flex-row-center-center();
@@ -1867,10 +1872,15 @@ a:hover {
     }
   }
 
+  .ui.label {
+    flex-grow: 1;
+    text-align: right;
+  }
+
   // multiple is used to make sure filter menu stays open, but it adds extra
   // margin on text
   .ui.multiple.dropdown > .text {
-    margin: 0px ;    
+    margin: 0px;
   }
   .ui.multiple.dropdown {
     padding: 5px 10px 5px 10px;
@@ -2386,7 +2396,7 @@ a:hover {
     gap: 10px;
     flex-wrap: wrap;
   }
-  .bottom-left {  
+  .bottom-left {
     bottom: @toastBottomMargin;
     left: @toastHorizontalMargin;
     max-height: calc(100vh - @toastBottomMargin);
@@ -2401,7 +2411,7 @@ a:hover {
     bottom: @toastBottomMargin;
     right: @toastHorizontalMargin;
     max-height: calc(100vh - @toastBottomMargin);
-    flex-wrap: wrap-reverse
+    flex-wrap: wrap-reverse;
   }
   .top-left {
     top: @toastTopMargin;
@@ -2409,16 +2419,16 @@ a:hover {
     max-height: calc(100vh - @toastTopMargin);
   }
   .top-middle {
-    top:  @toastTopMargin;
+    top: @toastTopMargin;
     left: 50%;
     transform: translateX(-50%);
     max-height: calc(100vh - @toastTopMargin);
   }
   .top-right {
-    top:  @toastTopMargin;
+    top: @toastTopMargin;
     right: @toastHorizontalMargin;
     max-height: calc(100vh - @toastTopMargin);
-    flex-wrap: wrap-reverse
+    flex-wrap: wrap-reverse;
   }
 }
 
@@ -2431,7 +2441,10 @@ a:hover {
   .toast-message {
     width: fit-content !important;
     max-width: 350px;
-    p { word-wrap: break-word; max-width: 250px;}
+    p {
+      word-wrap: break-word;
+      max-width: 250px;
+    }
   }
   .icon.info {
     color: @information;
@@ -2486,7 +2499,7 @@ a:hover {
     margin-bottom: 0.5em;
   }
   ul {
-    margin:0;
+    margin: 0;
   }
   li {
     margin-bottom: 0.5em;

--- a/src/containers/DataDisplay/DataViewTable.tsx
+++ b/src/containers/DataDisplay/DataViewTable.tsx
@@ -97,6 +97,7 @@ const DataViewTable: React.FC<{ codeFromLookupTable?: string }> = ({ codeFromLoo
               filterDefinitions={filterDefinitions}
               filterListParameters={{}}
               defaultFilterString={dataViewTable?.defaultFilterString ?? null}
+              totalCount={dataViewTable?.totalCount ?? null}
             />
           )}
           {codeFromLookupTable && searchComponent}

--- a/src/containers/DataDisplay/DataViewTable.tsx
+++ b/src/containers/DataDisplay/DataViewTable.tsx
@@ -93,7 +93,11 @@ const DataViewTable: React.FC<{ codeFromLookupTable?: string }> = ({ codeFromLoo
         )}
         <div className="flex-row-space-between-center" style={{ width: '100%' }}>
           {filterDefinitions && (
-            <ListFilters filterDefinitions={filterDefinitions} filterListParameters={{}} />
+            <ListFilters
+              filterDefinitions={filterDefinitions}
+              filterListParameters={{}}
+              defaultFilterString={dataViewTable?.defaultFilterString ?? null}
+            />
           )}
           {codeFromLookupTable && searchComponent}
         </div>

--- a/src/containers/List/ListFilters/ListFilters.tsx
+++ b/src/containers/List/ListFilters/ListFilters.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Dropdown, Icon, Label } from 'semantic-ui-react'
+import { Dropdown, Icon } from 'semantic-ui-react'
 import { useLanguageProvider } from '../../../contexts/Localisation'
 import { useRouter } from '../../../utils/hooks/useRouter'
 import { FilterDefinitions } from '../../../utils/types'
@@ -272,12 +272,13 @@ const ListFilters: React.FC<{
             return null
         }
       })}
-      {totalCount && (
-        <Label size="big">
-          <Icon name="folder open" />
-          {totalCount}
-        </Label>
-      )}
+      {totalCount ? (
+        <p className="result-count">
+          {totalCount === 1
+            ? strings.APPLICATIONS_LIST_TOTAL_RESULTS_SINGLE
+            : strings.APPLICATIONS_LIST_TOTAL_RESULTS.replace('%1', String(totalCount))}
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/src/containers/List/ListFilters/ListFilters.tsx
+++ b/src/containers/List/ListFilters/ListFilters.tsx
@@ -41,7 +41,7 @@ const ListFilters: React.FC<{
   totalCount: number | null
 }> = ({ filterDefinitions, filterListParameters, defaultFilterString, totalCount = null }) => {
   const { strings } = useLanguageProvider()
-  const { query, updateQuery, location } = useRouter()
+  const { query, updateQuery, location, setQuery } = useRouter()
 
   const displayableFilters = getDisplayableFilters(filterDefinitions)
   const defaultDisplayFilters = getDefaultDisplayFilters(filterDefinitions)
@@ -89,9 +89,8 @@ const ListFilters: React.FC<{
   }
 
   const resetFilters = () => {
-    updateQuery(Object.fromEntries(activeFilters.map((filterName) => [filterName, undefined])))
     setActiveFilters(defaultDisplayFilters)
-    updateQuery(defaultFilterString)
+    setQuery(defaultFilterString)
   }
 
   const availableFilterNames = filterNames.filter(

--- a/src/containers/List/ListFilters/ListFilters.tsx
+++ b/src/containers/List/ListFilters/ListFilters.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Dropdown, Icon } from 'semantic-ui-react'
+import { Dropdown, Icon, Label } from 'semantic-ui-react'
 import { useLanguageProvider } from '../../../contexts/Localisation'
 import { useRouter } from '../../../utils/hooks/useRouter'
 import { FilterDefinitions } from '../../../utils/types'
@@ -38,7 +38,8 @@ const ListFilters: React.FC<{
   filterDefinitions: FilterDefinitions
   filterListParameters: any
   defaultFilterString?: string | null
-}> = ({ filterDefinitions, filterListParameters, defaultFilterString }) => {
+  totalCount: number | null
+}> = ({ filterDefinitions, filterListParameters, defaultFilterString, totalCount = null }) => {
   const { strings } = useLanguageProvider()
   const { query, updateQuery, location } = useRouter()
 
@@ -271,6 +272,12 @@ const ListFilters: React.FC<{
             return null
         }
       })}
+      {totalCount && (
+        <Label size="big">
+          <Icon name="folder open" />
+          {totalCount}
+        </Label>
+      )}
     </div>
   )
 }

--- a/src/containers/List/ListFilters/ListFilters.tsx
+++ b/src/containers/List/ListFilters/ListFilters.tsx
@@ -37,7 +37,8 @@ const getDefaultDisplayFilters = (filterDefinitions: FilterDefinitions) =>
 const ListFilters: React.FC<{
   filterDefinitions: FilterDefinitions
   filterListParameters: any
-}> = ({ filterDefinitions, filterListParameters }) => {
+  defaultFilterString?: string | null
+}> = ({ filterDefinitions, filterListParameters, defaultFilterString }) => {
   const { strings } = useLanguageProvider()
   const { query, updateQuery, location } = useRouter()
 
@@ -89,6 +90,7 @@ const ListFilters: React.FC<{
   const resetFilters = () => {
     updateQuery(Object.fromEntries(activeFilters.map((filterName) => [filterName, undefined])))
     setActiveFilters(defaultDisplayFilters)
+    updateQuery(defaultFilterString)
   }
 
   const availableFilterNames = filterNames.filter(

--- a/src/containers/List/ListWrapper.tsx
+++ b/src/containers/List/ListWrapper.tsx
@@ -139,6 +139,7 @@ const ListWrapper: React.FC = () => {
       <ListFilters
         filterDefinitions={visibleFilters}
         filterListParameters={{ userId: currentUser?.userId || 0, templateCode: type }}
+        totalCount={applicationCount}
       />
       {columns && (
         <ApplicationsList

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -29,7 +29,9 @@ export default {
   APPLICATION_DELETION_CONFIRM_MESSAGE:
     'Please confirm you would like to delete a draft application',
   APPLICATIONS_LIST_EMPTY: 'No applications found',
-  APPLICATION_MISSING_TEMPLATE: "The applicantion's template was not found",
+  APPLICATIONS_LIST_TOTAL_RESULTS: '%1 results',
+  APPLICATIONS_LIST_TOTAL_RESULTS_SINGLE: '1 result',
+  APPLICATION_MISSING_TEMPLATE: "The application's template was not found",
   APPLICATION_OTHER_CHANGES_MADE: 'This is a new submission and will require a review.',
   ASSIGNED: 'assigned',
   ASSIGNED_TO: 'assigned to',

--- a/src/utils/hooks/useRouter.tsx
+++ b/src/utils/hooks/useRouter.tsx
@@ -58,9 +58,11 @@ export function useRouter(): RouterResult {
     const queryFilters = replaceKebabCaseKeys(queryString.parse(location.search, { sort: false }))
 
     // Add new key-value pairs to existing query string and update URL
-    const updateQuery = (newQueries: { [key: string]: string }, replace = false) => {
+    const updateQuery = (queryInput: { [key: string]: string }, replace = false) => {
+      const inputQueryObject =
+        typeof queryInput === 'string' ? parseQueryString(queryInput) : queryInput
       const newQueryObject = { ...queryFilters }
-      Object.entries(newQueries).forEach(([key, value]) => {
+      Object.entries(inputQueryObject).forEach(([key, value]) => {
         if (!value) {
           delete newQueryObject[key]
         } else newQueryObject[key] = value
@@ -103,4 +105,9 @@ export function useRouter(): RouterResult {
       history,
     }
   }, [location])
+}
+
+const parseQueryString = (queryString: string): { [key: string]: string } => {
+  const queries = queryString.split('&').map((query) => query.split('='))
+  return Object.fromEntries(queries)
 }

--- a/src/utils/hooks/useRouter.tsx
+++ b/src/utils/hooks/useRouter.tsx
@@ -10,6 +10,7 @@ interface RouterResult {
   push: (path: string, state?: any) => void
   query: BasicStringObject
   updateQuery: Function
+  setQuery: Function
   replace: (path: string) => void
   match: match
   history: any
@@ -60,7 +61,7 @@ export function useRouter(): RouterResult {
     // Add new key-value pairs to existing query string and update URL
     const updateQuery = (queryInput: { [key: string]: string }, replace = false) => {
       const inputQueryObject =
-        typeof queryInput === 'string' ? parseQueryString(queryInput) : queryInput
+        typeof queryInput === 'string' ? queryString.parse(queryInput) : queryInput
       const newQueryObject = { ...queryFilters }
       Object.entries(inputQueryObject).forEach(([key, value]) => {
         if (!value) {
@@ -81,6 +82,20 @@ export function useRouter(): RouterResult {
         })
     }
 
+    const setQuery = (queryInput: { [key: string]: string }, replace = false) => {
+      const queryObject =
+        typeof queryInput === 'string' ? queryString.parse(queryInput) : queryInput
+
+      if (replace)
+        history.replace({
+          search: queryString.stringify(restoreKebabCaseKeys(queryObject), { sort: false }),
+        })
+      else
+        history.push({
+          search: queryString.stringify(restoreKebabCaseKeys(queryObject), { sort: false }),
+        })
+    }
+
     return {
       // For convenience add push(), replace(), pathname at top level
       push: history.push,
@@ -96,6 +111,7 @@ export function useRouter(): RouterResult {
         ...params,
       },
       updateQuery,
+      setQuery,
 
       // Include match, location, history objects so we have
       // access to extra React Router functionality if needed.
@@ -105,9 +121,4 @@ export function useRouter(): RouterResult {
       history,
     }
   }, [location])
-}
-
-const parseQueryString = (queryString: string): { [key: string]: string } => {
-  const queries = queryString.split('&').map((query) => query.split('='))
-  return Object.fromEntries(queries)
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -739,6 +739,7 @@ export interface DataViewsTableResponse {
   tableRows: TableRow[]
   searchFields: string[]
   filterDefinitions: DataViewFilterDefinition[]
+  defaultFilterString: string | null
   totalCount: number
   message?: string
 }


### PR DESCRIPTION
Fix #1486 

Requires back-end: https://github.com/openmsupply/conforma-server/pull/1032

To test, go to the Provisional Product Register (Fiji) data view. It should launch with the "isActive=true" filter. Change and update some additional filters, then select "Reset all filters" from Filter button menu. The default `isActive=true` filter should remain (it doesn't in develop). 

Also added a label showing the total result count for all tables (Data Views and Applications List) so user doesn't have to perform mental arithmetic to figure out how many items there are in total for the current table/filter:
![Screenshot 2023-04-13 at 12 40 41 PM](https://user-images.githubusercontent.com/5456533/231616150-db41b02a-a671-4c05-8a40-be3894115bfa.png)

See inline comment for more details.