### PR TITLE
#1498 Markdown translation method

### DIFF
--- a/src/components/Admin/AdminPreferences.tsx
+++ b/src/components/Admin/AdminPreferences.tsx
@@ -10,7 +10,7 @@ import getServerUrl from '../../utils/helpers/endpoints/endpointUrlBuilder'
 import Loading from '../Loading'
 
 export const AdminPreferences: React.FC = () => {
-  const { t } = useLanguageProvider()
+  const { t, tFormat } = useLanguageProvider()
   usePageTitle(t('PAGE_TITLE_PREFS'))
 
   const showToast = useToast({ position: topLeft })
@@ -102,14 +102,7 @@ export const AdminPreferences: React.FC = () => {
     <div id="preferences-panel">
       <WarningModal />
       <Header>{t('PREFERENCES_HEADER')}</Header>
-      <p>
-        {/* TO-DO Localise this, need to find a way to include links in string */}
-        See the{' '}
-        <a href="https://github.com/openmsupply/conforma-server/wiki/Preferences" target="_blank">
-          server documentation
-        </a>{' '}
-        for an explanation of available preferences
-      </p>
+      <p>{tFormat('PREFERENCES_SEE_DOCS')}</p>
       {prefs ? (
         <ReactJson
           src={prefs}

--- a/src/contexts/Localisation.tsx
+++ b/src/contexts/Localisation.tsx
@@ -4,6 +4,7 @@ import strings from '../utils/defaultLanguageStrings'
 import { getRequest } from '../utils/helpers/fetchMethods'
 import getServerUrl from '../utils/helpers/endpoints/endpointUrlBuilder'
 import { mapValues } from 'lodash'
+import Markdown from '../utils/helpers/semanticReactMarkdown'
 
 const { pluginsFolder } = config
 
@@ -51,6 +52,11 @@ type Substitutions = Record<string, unknown> | string | number
 
 export type TranslateMethod = (key: keyof typeof strings, substitutions?: Substitutions) => string
 
+type TranslateMarkdownMethod = (
+  key: keyof typeof strings,
+  substitutions?: Substitutions
+) => JSX.Element
+
 type TranslatePluginMethod = (key: string, substitutions?: Substitutions) => string
 
 const initialContext: {
@@ -63,6 +69,8 @@ const initialContext: {
   refetchLanguages: Function
   translate: TranslateMethod
   t: TranslateMethod
+  translateMarkdown: TranslateMarkdownMethod
+  tFormat: TranslateMarkdownMethod
   getPluginTranslator: (pluginCode: string) => TranslatePluginMethod
 } = {
   selectedLanguage: initSelectedLanguage,
@@ -74,6 +82,8 @@ const initialContext: {
   refetchLanguages: () => {},
   translate: () => '',
   t: () => '',
+  translateMarkdown: () => <></>,
+  tFormat: () => <></>,
   getPluginTranslator: () => () => '',
 }
 
@@ -164,6 +174,15 @@ export function LanguageProvider({
   const translate: TranslateMethod = (key, substitutions = {}) =>
     getTranslation(languageState.strings, key, substitutions)
 
+  const translateMarkdown: TranslateMarkdownMethod = (key, substitutions = {}) => {
+    return (
+      <Markdown
+        text={getTranslation(languageState.strings, key, substitutions)}
+        semanticComponent="noParagraph"
+      />
+    )
+  }
+
   const translatePlugin = (pluginCode: string, key: string, substitutions: Substitutions = {}) => {
     const pluginStrings = getPluginStrings(pluginCode)
     return getTranslation(pluginStrings, key, substitutions)
@@ -197,6 +216,8 @@ export function LanguageProvider({
         refetchLanguages,
         translate,
         t: translate,
+        translateMarkdown: translateMarkdown,
+        tFormat: translateMarkdown,
         getPluginTranslator: (pluginCode) => (key, substitutions) =>
           translatePlugin(pluginCode, key, substitutions),
       }}

--- a/src/contexts/Localisation.tsx
+++ b/src/contexts/Localisation.tsx
@@ -256,7 +256,7 @@ const getTranslation = (
   substitutions: Substitutions
 ) => {
   let localisedString = strings[key]
-  if (!localisedString) return key
+  if (localisedString === undefined) return key
 
   if (typeof substitutions === 'string' || typeof substitutions === 'number') {
     const match = localisedString.match(/{{([A-z0-9]+)}}/m)

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -317,6 +317,8 @@ export default {
   PAGE_TITLE_PERMISSIONS: 'Permissions',
   PLACEHOLDER_SEARCH: 'Search Applications...',
   PREFERENCES_HEADER: 'System Preferences',
+  PREFERENCES_SEE_DOCS:
+    'See the [server documentation](https://github.com/openmsupply/conforma-server/wiki/Preferences) for an explanation of available preferences',
   PREFERENCES_SAVE_WARNING: 'Save system preferences?',
   PREFERENCES_SAVE_MESSAGE:
     'Are you sure?  This will overwrite core settings and can break the system if misconfigured',


### PR DESCRIPTION
Fix #1498.

Based off #1497 

This is a much more straightforward (and easier to implement) solution than my original suggestion. We just have an additional "translateMarkdown" (shorthand `tFormat`) method returned from the LanguageProvider, and only language strings that have formatting in them need to be passed to it.

(Will need to make sure you have at least https://github.com/openmsupply/conforma-server/pull/1038 branch in back-end so the "Preferences" page works)

Currently only implemented in one place, the System Preferences.


UPDATE: Added a quick fix for #1503 in here as well.