### PR TITLE
Prevent Markdown link clicks from propogating event

### DIFF
--- a/src/utils/helpers/semanticReactMarkdown.tsx
+++ b/src/utils/helpers/semanticReactMarkdown.tsx
@@ -57,7 +57,11 @@ const MarkdownBlock: React.FC<MarkdownBlockProps> = (props) => {
   const linkRenderer = {
     link: (props: any) => {
       return !props.href.startsWith('http') ? (
-        <Link to={{ pathname: props.href }} target={newTabLinks ? '_blank' : undefined}>
+        <Link
+          to={{ pathname: props.href }}
+          target={newTabLinks ? '_blank' : undefined}
+          onClick={(e) => e.stopPropagation()}
+        >
           {props.children}
         </Link>
       ) : (


### PR DESCRIPTION
To prevent the problem discovered with @fergie-nz, where the whole table row has an "onClick" event already. 