### PR TITLE
"useDefault" option for File Upload

### DIFF
--- a/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
+++ b/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
@@ -7,6 +7,7 @@ import { useUserState } from '../../../contexts/UserState'
 import { postRequest } from '../../../utils/helpers/fetchMethods'
 import { FileDisplay, FileDisplayWithDescription } from './components'
 import getServerUrl from '../../../utils/helpers/endpoints/endpointUrlBuilder'
+import useDefault from '../../useDefault'
 
 export interface FileResponseData {
   uniqueId: string
@@ -48,6 +49,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     fileCountLimit,
     fileExtensions,
     fileSizeLimit,
+    default: defaultValue,
     showDescription = false,
     ...fileOptions
   } = parameters
@@ -80,6 +82,15 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       files: fileDataToSave,
     })
   }, [uploadedFiles])
+
+  useDefault({
+    defaultValue,
+    currentResponse,
+    parameters,
+    onChange: (defaultFiles) => {
+      setUploadedFiles(generateInitialFileData(defaultFiles?.files ?? []))
+    },
+  })
 
   const errors = [
     {

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -24,6 +24,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     optionsDisplayProperty,
     hasOther,
     otherPlaceholder,
+    persistUserInput,
     layout,
   } = parameters
 
@@ -44,7 +45,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   useDefault({
     defaultValue,
-    currentResponse,
+    currentResponse: persistUserInput ? currentResponse : null,
     parameters,
     onChange: (defaultOption) => {
       const optionIndex = getDefaultIndex(defaultOption, options)


### PR DESCRIPTION
Just adds the ability for file upload elements to have a default.

To see it in action, it's applied to the GMP Certificate and Product Registration Certificate fields of the "Product Correction" template (MPCOR2) in Fiji.