### PR TITLE
#177T (Pre)view applications from review/assign page

### DIFF
--- a/src/containers/Review/assignment/AssignmentSectionRow.tsx
+++ b/src/containers/Review/assignment/AssignmentSectionRow.tsx
@@ -119,12 +119,12 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
   return (
     <Grid columns={2} className="section-single-row-box-container">
       <Grid.Row className="assigning-row">
-        <Grid.Column className="review-level" width={7}>
+        <Grid.Column className="review-level" width={5}>
           <Label className="simple-label">
             {t('REVIEW_FILTER_LEVEL')}: <strong>{levelName}</strong>
           </Label>
         </Grid.Column>
-        <Grid.Column className="centered-flex-box-row" width={9}>
+        <Grid.Column className="centered-flex-box-row" width={8}>
           {originalAssignee && assignmentOptions.isSubmitted ? (
             <AssigneeLabel
               assignee={originalAssignee}
@@ -145,6 +145,17 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
                 onChangeMethod={(selected: number) => onAssigneeSelection(selected)}
               />
             </>
+          )}
+        </Grid.Column>
+        <Grid.Column className="centered-flex-box-row" width={3}>
+          {!assignmentOptions.isSubmitted && (
+            <a
+              className="user-action clickable"
+              style={{ textAlign: 'center' }}
+              onClick={() => window.open(`/application/${structure.info.serial}`)}
+            >
+              {t('ACTION_PREVIEW_APPLICATION')}
+            </a>
           )}
         </Grid.Column>
       </Grid.Row>

--- a/src/containers/Review/overview/Overview.tsx
+++ b/src/containers/Review/overview/Overview.tsx
@@ -83,40 +83,54 @@ export const Overview: React.FC<{
                 </p>
               )}
             </div>
-            {applicantDeadline &&
-              // If the deadline is active, then it must be PENDING. If it's
-              // inactive, then we only want to show the button when it's
-              // EXPIRED, so cancelled deadlines don't cause the button to show.
-              ((applicantDeadline.isActive && outcome === ApplicationOutcome.Pending) ||
-                (!applicantDeadline.isActive && outcome === ApplicationOutcome.Expired)) && (
-                <div className="flex-row-start-center" style={{ gap: 10, marginTop: 30 }}>
-                  {t('REVIEW_OVERVIEW_EXTEND_BY')}
-                  <Form.Input
-                    size="mini"
-                    type="number"
-                    min={1}
-                    value={deadlineDays}
-                    onChange={(e) => setDeadlineDays(Number(e.target.value))}
-                    style={{ maxWidth: 65 }}
-                  />
-                  <span style={{ marginRight: 20 }}>{t('REVIEW_OVERVIEW_DAYS', deadlineDays)}</span>
-                  <Button
-                    primary
-                    inverted
-                    onClick={() =>
-                      showModal({
-                        message: t('REVIEW_OVERVIEW_MODAL_MESSAGE', deadlineDays),
-                        onConfirm: async () => {
-                          await extendDeadline(id, deadlineDays)
-                          reload()
-                        },
-                      })
-                    }
-                  >
-                    {t('REVIEW_OVERVIEW_BUTTON_EXTEND')}
-                  </Button>
-                </div>
-              )}
+            <div className="flex-row-space-between wrap">
+              {applicantDeadline &&
+                // If the deadline is active, then it must be PENDING. If it's
+                // inactive, then we only want to show the button when it's
+                // EXPIRED, so cancelled deadlines don't cause the button to show.
+                ((applicantDeadline.isActive && outcome === ApplicationOutcome.Pending) ||
+                  (!applicantDeadline.isActive && outcome === ApplicationOutcome.Expired)) && (
+                  <div className="flex-row-start-center" style={{ gap: 10, marginTop: 30 }}>
+                    {t('REVIEW_OVERVIEW_EXTEND_BY')}
+                    <Form.Input
+                      size="mini"
+                      type="number"
+                      min={1}
+                      value={deadlineDays}
+                      onChange={(e) => setDeadlineDays(Number(e.target.value))}
+                      style={{ maxWidth: 65 }}
+                    />
+                    <span style={{ marginRight: 20 }}>
+                      {t('REVIEW_OVERVIEW_DAYS', deadlineDays)}
+                    </span>
+                    <Button
+                      primary
+                      inverted
+                      onClick={() =>
+                        showModal({
+                          message: t('REVIEW_OVERVIEW_MODAL_MESSAGE', deadlineDays),
+                          onConfirm: async () => {
+                            await extendDeadline(id, deadlineDays)
+                            reload()
+                          },
+                        })
+                      }
+                    >
+                      {t('REVIEW_OVERVIEW_BUTTON_EXTEND')}
+                    </Button>
+                  </div>
+                )}
+              <div style={{ alignSelf: 'flex-end', marginTop: 20 }}>
+                <Button
+                  primary
+                  onClick={() => {
+                    window.open(`/application/${serial}`)
+                  }}
+                >
+                  {t('REVIEW_OVERVIEW_VIEW_APPLICATION')}
+                </Button>
+              </div>
+            </div>
           </Message.Content>
         </Message>
         <ConfirmModal />

--- a/src/containers/Review/overview/OverviewTab.tsx
+++ b/src/containers/Review/overview/OverviewTab.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Container, Header } from 'semantic-ui-react'
+import { Button, Container, Header } from 'semantic-ui-react'
 import Loading from '../../../components/Loading'
 import { useLanguageProvider } from '../../../contexts/Localisation'
 import { FullStructure } from '../../../utils/types'

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -16,6 +16,7 @@ export default {
   ACTION_RE_ASSIGN: 'Re-Assign',
   ACTION_SELF_ASSIGN: 'Self-Assign',
   ACTION_UNASSIGN: 'Un-assign',
+  ACTION_PREVIEW_APPLICATION: 'Preview application',
   ACTION_UPDATE: 'Update',
   ACTION_VIEW: 'View',
   ACTION_MAKE_CHANGES: 'Make changes',
@@ -344,6 +345,7 @@ export default {
   REVIEW_OVERVIEW_MODAL_MESSAGE: "This will extend the applicant's deadline by {{count}} days",
   REVIEW_OVERVIEW_MODAL_MESSAGE_1: "This will extend the applicant's deadline by one day",
   REVIEW_OVERVIEW_BUTTON_EXTEND: 'Extend',
+  REVIEW_OVERVIEW_VIEW_APPLICATION: 'View application',
   REVIEW_PROGRESS_BAR_SUBMITTED: 'Submitted',
   REVIEW_SUBMISSION_CONFIRM_TITLE: 'Submitting Review',
   REVIEW_SUBMISSION_CONFIRM_MESSAGE:


### PR DESCRIPTION
Fix https://github.com/openmsupply/conforma-templates/issues/177

Just adds a permanent "View application" button to the Review home page (Overview), and a "Preview application" link to the Assignment interface (only when currently not assigned)

![Screenshot 2023-06-15 at 1 18 04 PM](https://github.com/openmsupply/conforma-templates/assets/5456533/607210a1-ecef-41de-9c5c-2d2a2ef4eafe)
![Screenshot 2023-06-15 at 1 18 07 PM](https://github.com/openmsupply/conforma-templates/assets/5456533/bd98a257-29e9-4bef-8c18-4f462a1e4842)

This should only show up when there are assignments to be done:
![Screenshot 2023-06-15 at 2 05 44 PM](https://github.com/openmsupply/conforma-web-app/assets/5456533/58686e5b-5b37-47f6-b2f5-ced9d8114576)
