### PR TITLE
#1525 Sort and Filter for templates list

### DIFF
--- a/src/containers/TemplateBuilder/Templates.tsx
+++ b/src/containers/TemplateBuilder/Templates.tsx
@@ -161,8 +161,11 @@ const Templates: React.FC = () => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const { templates, refetch } = useGetTemplates()
   const { importTemplate } = useOperationState()
-  const [hideInactive, setHideInactive] = useState(false)
-  const [selectedCategories, setSelectedCategories] = useState<string[]>([])
+  const { query, updateQuery } = useRouter()
+  const [hideInactive, setHideInactive] = useState(query.hideInactive === 'true')
+  const [selectedCategories, setSelectedCategories] = useState<string[]>(
+    query.categories ? query.categories.split(',').map((cat) => (cat === 'none' ? '' : cat)) : []
+  )
   const [sortColumn, setSortColumn] = useState<SortColumn>()
   const [sortAsc, setSortAsc] = useState<1 | -1>(1)
 
@@ -175,10 +178,12 @@ const Templates: React.FC = () => {
   const changeSort = (column: SortColumn) => {
     if (column === sortColumn) {
       setSortAsc(-sortAsc as 1 | -1)
+      updateQuery({ desc: !query.desc })
       return
     }
     setSortColumn(column)
     setSortAsc(1)
+    updateQuery({ sort: column, desc: false })
   }
 
   const renderHeader = () => (
@@ -286,15 +291,27 @@ const Templates: React.FC = () => {
           <div className="flex-row-end" style={{ alignItems: 'center', gap: 20 }}>
             <Checkbox
               label="Hide Inactive"
+              checked={hideInactive}
               toggle
-              onChange={() => setHideInactive(!hideInactive)}
+              onChange={() => {
+                updateQuery({ hideInactive: !hideInactive })
+                setHideInactive(!hideInactive)
+              }}
             />
             <Dropdown
               placeholder="Filter by category"
               selection
               multiple
+              value={selectedCategories}
               options={categoryOptions}
-              onChange={(_, { value }) => setSelectedCategories(value as string[])}
+              onChange={(_, { value }) => {
+                updateQuery({
+                  categories: (value as string[])
+                    .map((cat) => (cat === '' ? 'none' : cat))
+                    .join(','),
+                })
+                setSelectedCategories(value as string[])
+              }}
               style={{ maxWidth: 350 }}
             />
           </div>

--- a/src/containers/TemplateBuilder/Templates.tsx
+++ b/src/containers/TemplateBuilder/Templates.tsx
@@ -82,7 +82,7 @@ const ViewEditButton: React.FC<CellProps> = ({ template: { id } }) => {
       className="clickable"
       onClick={(e) => {
         e.stopPropagation()
-        push(`/admin/template/${id}/general`)
+        push(`/admin/template/${id}/general`, { queryString: location.search })
       }}
     >
       <Icon name="edit outline" />

--- a/src/containers/TemplateBuilder/template/TemplateWrapper.tsx
+++ b/src/containers/TemplateBuilder/template/TemplateWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react'
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react'
 import { matchPath } from 'react-router'
 import { Link } from 'react-router-dom'
 import { Header, Icon, Message, Label } from 'semantic-ui-react'
@@ -70,6 +70,7 @@ const TemplateContainer: React.FC = () => {
   const {
     template: { version, name, code, status, applicationCount, id },
   } = useTemplateState()
+  const prevQuery = useRef(location?.state?.queryString ?? '')
 
   const selected = tabs.find(({ route }) =>
     matchPath(location.pathname, { path: `${path}/${route}`, exact: true, strict: false })
@@ -81,7 +82,7 @@ const TemplateContainer: React.FC = () => {
     <div className="template-builder-wrapper">
       <Label
         className="back-label clickable"
-        onClick={() => push(`/admin/templates`)}
+        onClick={() => push(`/admin/templates${prevQuery.current}`)}
         content={
           <>
             <Icon name="chevron left" className="dark-grey" />


### PR DESCRIPTION
Fix #1525 

Basic sorting and filtering for Templates list. Should make it a bit easier to find what we're looking for and organise categories, etc.

No need to make a new database query, since we're already pulling the whole data set -- so this is just an in-place rearrangement of the DB result.