### PR TITLE
#1530 Date picker allowed range fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-markdown": "^5.0.3",
     "react-progress-stepper": "^0.2.2",
     "react-router-dom": "^5.3.3",
-    "react-semantic-ui-datepickers": "^2.13.1",
+    "react-semantic-ui-datepickers": "^2.17.2",
     "react-string-replace": "^0.4.4",
     "serve": "^11.3.2",
     "use-undo": "^1.1.1"

--- a/src/formElementPlugins/datePicker/src/ApplicationView.tsx
+++ b/src/formElementPlugins/datePicker/src/ApplicationView.tsx
@@ -4,7 +4,6 @@ import SemanticDatepicker from 'react-semantic-ui-datepickers'
 import { DateTime } from 'luxon'
 import 'react-semantic-ui-datepickers/dist/react-semantic-ui-datepickers.css'
 import { useLanguageProvider } from '../../../contexts/Localisation'
-import { LocaleOptions } from 'react-semantic-ui-datepickers/dist/types'
 import useDefault from '../../useDefault'
 
 // Stored response date format
@@ -13,7 +12,8 @@ interface DateSaved {
   end?: string
 }
 
-// This is the type used by react-semantic-ui-datepicker, and what we use for local "value" here
+// This is the type used by react-semantic-ui-datepicker, and what we use for
+// local "value" here
 type SelectedDateRange = Date[] | Date | null
 
 type DateFormats = 'short' | 'med' | 'medWeekday' | 'full' | 'huge'
@@ -74,6 +74,21 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   const handleSelect = (date?: SelectedDateRange) => {
     if (date === undefined) return
+
+    // The DatePicker component doesn't check that date falls within allowed
+    // range when it is manually entered, so we need to check it here.
+    const [minDate, maxDate] =
+      date instanceof Date ? [date, date] : Array.isArray(date) ? [date[0], date[1]] : [null, null]
+    if (
+      minDate !== null &&
+      maxDate !== null &&
+      (minDate < minDateValue || maxDate > maxDateValue)
+    ) {
+      console.log('Selected date outside allowed range')
+      setSelectedDate(null)
+      return
+    }
+
     setSelectedDate(date)
     onSave({ text: toDisplayString(date, locale, displayFormat), date: toDateSaved(date) })
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,13 +466,6 @@
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/runtime@7.13.10":
-  version "7.13.10"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
-  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.10.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
@@ -2256,10 +2249,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
-  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+classnames@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
 
 clean-css@^4.2.3:
   version "4.2.3"
@@ -2555,11 +2548,6 @@ copy-concurrently@^1.0.0:
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
-
-core-js@3.13.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.13.1.tgz#30303fabd53638892062d8b4e802cac7599e9fb7"
-  integrity sha512-JqveUc4igkqwStL2RTRn/EPFGBOfEZHxJl/8ej1mXJR75V3go2mFF4bmUYkEIT1rveHKnkUlcJX/c+f1TyIovQ==
 
 core-js@^2.4.1:
   version "2.6.11"
@@ -2892,19 +2880,24 @@ dataloader@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
 
-date-fns@2.22.1, date-fns@^2.0.0, date-fns@^2.1:
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
-  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
+date-fns@2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
 
-dayzed@3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/dayzed/-/dayzed-3.2.2.tgz#2b78858d86987ee14fd03fcb187d2d17638d0cdd"
-  integrity sha512-BzNoj+6+er5DPQ0F82Yh1U8MU/jyOo7R+jIlK9FsSjfk4ZIISalygzMcsXTGTFedm5UfTddQnELMVBQUXZDv9Q==
+date-fns@^2.0.0, date-fns@^2.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
+  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
+
+dayzed@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/dayzed/-/dayzed-3.2.3.tgz#78c5ab7e28579cd3c0f9f848b744ac5c768e9a22"
+  integrity sha512-qXTIKs+R6ydWwNo+X1wu3lUptyRSGoyY+ZzRcQSM0zUlaG+/Ei+bFjqbQm1T2oJ+WKNkTHURBcGsxnx9N+9kfA==
   dependencies:
     "@babel/runtime" "^7.6.2"
     date-fns "^2.0.0"
@@ -7295,17 +7288,15 @@ react-router@5.3.3:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-semantic-ui-datepickers@^2.13.1:
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/react-semantic-ui-datepickers/-/react-semantic-ui-datepickers-2.13.2.tgz#c13f3274a270955611c6b9f20690f89d46a38af6"
-  integrity sha512-8DVzAPcN4gjOYUCpNPN/QkcC1Gy7S+XqAfHWX+F8ne3CoEg/uLfWYuT3wOsa6MIdSuoMRS9/Cf7PtAhNZihyDg==
+react-semantic-ui-datepickers@^2.17.2:
+  version "2.17.2"
+  resolved "https://registry.yarnpkg.com/react-semantic-ui-datepickers/-/react-semantic-ui-datepickers-2.17.2.tgz#a7ddbeecfa5e3129531eb7cdf364323942a1b9a4"
+  integrity sha512-rYFFwdPOi3C+7vP/KpU7jgj05BoVATEOAhlEvkeQhGtMfaxUIh/9eWF7Fas5QmUsyXXGrMm8alccIwKe34m5ug==
   dependencies:
-    "@babel/runtime" "7.13.10"
     "@date-fns/upgrade" "1.0.3"
-    classnames "2.3.1"
-    core-js "3.13.1"
-    date-fns "2.22.1"
-    dayzed "3.2.2"
+    classnames "2.3.2"
+    date-fns "2.29.3"
+    dayzed "3.2.3"
     format-string-by-pattern "1.2.2"
     react-fast-compare "3.2.0"
 


### PR DESCRIPTION
Fix #1530 

Adds an additional check that input date falls within allowed range.

I've also updated the `react-semantic-ui-datepickers` package to the latest version, so don't forget to `yarn`.