### PR TITLE
#1539 Make Submit button inactive while "loading"

### DIFF
--- a/src/utils/hooks/useConfirmationModal.tsx
+++ b/src/utils/hooks/useConfirmationModal.tsx
@@ -93,7 +93,11 @@ const useConfirmationModal = ({
           inverted
           icon="checkmark"
           content={modalState.confirmText}
-          onClick={() => handleConfirm(modalState.onConfirm)}
+          // This ensures that the "Confirm" action can only be triggered once.
+          // By default it can still be clicked while "loading". We can achieve
+          // this fix by adding `disabled={buttonLoading}`, but it doesn't look
+          // as nice :)
+          onClick={!buttonLoading ? () => handleConfirm(modalState.onConfirm) : () => {}}
         />
       </Modal.Actions>
     </Modal>


### PR DESCRIPTION
Fix #1539 

Kind of surprising to discover that the Semantic `<Button/>` is still clickable when it's in its "loading" state.

So this just prevents the "onConfirm" method from being called while it's "loading".

Also done a back-end fix to prevent this, too: https://github.com/openmsupply/conforma-server/pull/1058