### PR TITLE
#1059B #1042B File archive management

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -2118,7 +2118,6 @@ a:hover {
 }
 
 // Text sizes
-
 .smaller-text {
   font-size: @smallerText;
 }

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -162,9 +162,9 @@ a:hover {
   justify-content: flex-start;
 }
 
-.flex-column-start-stretch {
+.flex-column-start-start {
   .flex-column-start();
-  align-items: stretch;
+  align-items: start;
 }
 
 .flex-column-center-start {

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,7 @@ const config = {
     getApplicationData: '/admin/get-application-data',
     getAllPrefs: '/admin/get-all-prefs',
     setPrefs: '/admin/set-prefs',
+    archiveFiles: '/admin/archive-files',
   },
   version,
   pluginsFolder: 'formElementPlugins',

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -359,7 +359,7 @@ const Snapshots: React.FC = () => {
 
     const archiveEndOptions =
       typeof archive === 'number'
-        ? archiveOptions.filter(({ value }) => typeof value === 'number' && value > archive)
+        ? archiveOptions.filter(({ value }) => typeof value === 'number' && value >= archive)
         : []
 
     const hasArchives = data && data.currentArchives?.length > 0

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -355,9 +355,8 @@ const Snapshots: React.FC = () => {
     return <Label content={text} color={color} size="mini" />
   }
 
-  const newSnapshot = () => {
+  const renderNewSnapshot = () => {
     const [name, setName] = useState(localStorage.getItem('defaultSnapshotName') ?? '')
-    console.log('NAME', localStorage.getItem('defaultSnapshotName'))
     const archiveOptions =
       data && data.currentArchives?.length > 0
         ? [
@@ -427,9 +426,7 @@ const Snapshots: React.FC = () => {
           </Header>
           <Button
             primary
-            disabled={
-              !name || (data?.currentArchives && data?.currentArchives.length > 0 && !archive)
-            }
+            disabled={!name || (displayType === 'archives' && !archive)}
             onClick={() => {
               takeSnapshot(name)
             }}
@@ -483,7 +480,7 @@ const Snapshots: React.FC = () => {
 
       <Table stackable style={{ marginTop: 0 }}>
         <Table.Body>
-          <Table.Row>{newSnapshot()}</Table.Row>
+          <Table.Row>{renderNewSnapshot()}</Table.Row>
           {renderSnapshotList()}
         </Table.Body>
       </Table>

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -22,8 +22,6 @@ import TextIO from '../TemplateBuilder/shared/TextIO'
 import { fileSizeWithUnits } from '../../utils/helpers/utilityFunctions'
 import { useRouter } from '../../utils/hooks/useRouter'
 
-// const diffSnapshotUrl = `${snapshotsBaseUrl}/diff`
-
 type ArchiveType = { type: 'full' | 'none' | 'partial'; from?: string; to?: string }
 interface SnapshotData {
   name: string
@@ -170,8 +168,6 @@ const Snapshots: React.FC = () => {
     if (!event.target?.files) return
 
     const file = event.target.files[0]
-
-    console.log('URL', getServerUrl('snapshot', { action: 'upload' }))
 
     setIsLoading(true)
     try {

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -90,6 +90,8 @@ const Snapshots: React.FC = () => {
   const takeSnapshot = async (name: string) => {
     if (!name) return
 
+    localStorage.setItem('defaultSnapshotName', name)
+
     setIsLoading(true)
     try {
       const resultJson = await postRequest({
@@ -189,9 +191,6 @@ const Snapshots: React.FC = () => {
       setSnapshotError({ message: 'Front end error while uploading snapshot', error })
     }
   }
-
-  const formatTimestamp = (timestamp: string) =>
-    DateTime.fromISO(timestamp).toFormat('yyyy-LL-dd_HH-mm-ss')
 
   const downloadSnapshot = async (name: string) => {
     const res = await fetch(
@@ -357,7 +356,8 @@ const Snapshots: React.FC = () => {
   }
 
   const newSnapshot = () => {
-    const [name, setName] = useState('')
+    const [name, setName] = useState(localStorage.getItem('defaultSnapshotName') ?? '')
+    console.log('NAME', localStorage.getItem('defaultSnapshotName'))
     const archiveOptions =
       data && data.currentArchives?.length > 0
         ? [
@@ -382,6 +382,7 @@ const Snapshots: React.FC = () => {
         <div className="flex-column" style={{ gap: 10, width: '100%' }}>
           <Input
             onChange={(_, { value }) => setName(value)}
+            value={name}
             placeholder="Enter snapshot name"
             style={{ width: 200 }}
           />

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -234,9 +234,9 @@ const Snapshots: React.FC = () => {
                           showModal({
                             title: 'Are you sure?',
                             message: `This will overwrite ALL existing data on: ${window.location.host}`,
-                            onConfirm: () => useSnapshot(name),
+                            onConfirm: () => useSnapshot(filename),
                           })
-                        else useSnapshot(name)
+                        else useSnapshot(filename)
                       }}
                     />
                   )}
@@ -321,7 +321,7 @@ const Snapshots: React.FC = () => {
   }
 
   const renderLoadingAndError = () => (
-    <Modal open={isLoading} onClick={resetLoading} onClose={resetLoading}>
+    <Modal open={isLoading} onClose={resetLoading}>
       {snapshotError ? (
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           <Label size="large" color="red">

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -10,6 +10,7 @@ import {
   Header,
   SemanticCOLORS,
   Dropdown,
+  Form,
 } from 'semantic-ui-react'
 import config from '../../config'
 import getServerUrl from '../../utils/helpers/endpoints/endpointUrlBuilder'
@@ -442,12 +443,55 @@ const Snapshots: React.FC = () => {
     )
   }
 
+  const renderArchiveFiles = () => {
+    const [days, setDays] = useState(7)
+    const [loading, setLoading] = useState(false)
+
+    const archiveFiles = async () => {
+      setLoading(true)
+      const result = await getRequest(getServerUrl('archiveFiles', { days }))
+      showToast({
+        title: result === null ? 'Nothing to archive' : 'Archive complete',
+        text: result === null ? undefined : `${result.numFiles} files archived`,
+        style: result ? 'success' : 'warning',
+      })
+      setLoading(false)
+    }
+
+    return (
+      <div
+        className="flex-row-space-between-center"
+        style={{
+          marginTop: 10,
+          marginBottom: 5,
+          display: displayType === 'snapshots' ? 'none' : 'flex',
+        }}
+      >
+        <div className="flex-row-start-center" style={{ gap: 5 }}>
+          Archive files older than
+          <Form.Input
+            size="mini"
+            type="number"
+            min={0}
+            value={days}
+            onChange={(e) => setDays(Number(e.target.value))}
+            style={{ maxWidth: 65 }}
+          />
+          days
+        </div>
+        <Button primary inverted loading={loading} onClick={archiveFiles}>
+          Archive <Icon name="archive" style={{ paddingLeft: 5, transform: 'translateY(0px)' }} />
+        </Button>
+      </div>
+    )
+  }
+
   const renderUploadSnapshot = () => {
     const fileInputRef = useRef<HTMLInputElement>(null)
     return (
       <div>
         <Button primary inverted onClick={() => fileInputRef?.current?.click()}>
-          Upload <Icon name="upload" />
+          Upload <Icon name="upload" style={{ paddingLeft: 5 }} />
         </Button>
         <input
           type="file"
@@ -482,6 +526,7 @@ const Snapshots: React.FC = () => {
         </div>
         {renderUploadSnapshot()}
       </div>
+      {renderArchiveFiles()}
 
       <Table stackable style={{ marginTop: 0 }}>
         <Table.Body>

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -21,6 +21,7 @@ import { DateTime } from 'luxon'
 import TextIO from '../TemplateBuilder/shared/TextIO'
 import { fileSizeWithUnits } from '../../utils/helpers/utilityFunctions'
 import { useRouter } from '../../utils/hooks/useRouter'
+import Tooltip from '../../components/Tooltip'
 
 type ArchiveType = { type: 'full' | 'none' | 'partial'; from?: string; to?: string }
 interface SnapshotData {
@@ -279,15 +280,25 @@ const Snapshots: React.FC = () => {
                 {archive && (
                   <div className="flex-row-start-center" style={{ gap: 5 }}>
                     {archive.type !== 'none' && (
-                      <TextIO
-                        title={`Archive`}
-                        text={`${DateTime.fromISO(
-                          archive.from ?? ''
-                        ).toLocaleString()} – ${DateTime.fromISO(
-                          archive.to ?? ''
-                        ).toLocaleString()}`}
-                        additionalStyles={{ margin: 0 }}
-                      />
+                      <>
+                        <TextIO
+                          title={`Archive`}
+                          text={`${DateTime.fromISO(
+                            archive.from ?? ''
+                          ).toLocaleString()} – ${DateTime.fromISO(
+                            archive.to ?? ''
+                          ).toLocaleString()}`}
+                          additionalStyles={{ margin: 0 }}
+                        />
+                        <Tooltip
+                          message={`### Archives\n\nFrom: **${DateTime.fromISO(
+                            archive.from ?? ''
+                          ).toLocaleString(DateTime.DATETIME_MED)}**  \nTo: **${DateTime.fromISO(
+                            archive.to ?? ''
+                          ).toLocaleString(DateTime.DATETIME_MED)}**`}
+                          iconStyle={{ marginLeft: 0, height: 'auto' }}
+                        />
+                      </>
                     )}
                     {renderArchiveLabel(archive)}
                   </div>

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -400,7 +400,7 @@ const Snapshots: React.FC = () => {
                       value={archiveEnd}
                       options={archiveEndOptions}
                       onChange={(_, { value }) => {
-                        setArchiveEnd(value as number)
+                        setArchiveEnd(value === '' ? undefined : (value as number))
                       }}
                       style={{ maxWidth: 350 }}
                     />

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -366,6 +366,8 @@ const Snapshots: React.FC = () => {
         ? archiveOptions.filter(({ value }) => typeof value === 'number' && value > archive)
         : []
 
+    const hasArchives = data && data.currentArchives?.length > 0
+
     return (
       <Table.Cell className="flex-row-start-center" style={{ gap: 10, padding: 15 }}>
         <div className="flex-column" style={{ gap: 10, width: '100%' }}>
@@ -375,7 +377,7 @@ const Snapshots: React.FC = () => {
             placeholder="Enter snapshot name"
             style={{ width: 200 }}
           />
-          {data && data.currentArchives?.length > 0 && (
+          {hasArchives && (
             <div className="flex-row-start-center" style={{ gap: 10 }}>
               {typeof archive === 'number' && <span>From: </span>}
               <Dropdown
@@ -391,6 +393,7 @@ const Snapshots: React.FC = () => {
                 style={{ maxWidth: 350 }}
               />
               {typeof archive === 'number' &&
+                data &&
                 data?.currentArchives.filter(({ timestamp }) => timestamp > archive).length > 0 && (
                   <>
                     <span>to: </span>
@@ -416,7 +419,9 @@ const Snapshots: React.FC = () => {
           </Header>
           <Button
             primary
-            disabled={!name || (displayType === 'archives' && !archive)}
+            disabled={
+              !name || (hasArchives && !archive) || (displayType === 'archives' && !archive)
+            }
             onClick={() => {
               takeSnapshot(name)
             }}

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -84,57 +84,42 @@ const Snapshots: React.FC = () => {
   }
 
   const normaliseSnapshotName = (name: string) =>
-    name
-      // Not word, not digit
-      .replace(/[^\w\d]/g, '_')
-      // Remove "ARHIVE_" prefix
-      .replace(/^ARCHIVE_/, '')
-      // Remove timestamp suffix
-      .replace(/_\d\d\d\d_\d\d_\d\d_\d\d_\d\d_\d\d$/, '')
+    // Not word, not digit
+    name.replace(/[^\w\d-]/g, '_')
 
   const takeSnapshot = async (name: string) => {
     if (!name) return
 
-    const doOperation = async () => {
-      setIsLoading(true)
-      try {
-        const resultJson = await postRequest({
-          url: getServerUrl('snapshot', {
-            action: 'take',
-            name: normaliseSnapshotName(name),
-            archive: displayType === 'archives',
-          }),
-          jsonBody: {
-            archive:
-              typeof archive === 'string'
-                ? archive
-                : archive === undefined
-                ? 'full'
-                : { from: archive, to: archiveEnd },
-          },
-          headers: { 'Content-Type': 'application/json' },
-        })
-
-        if (resultJson.success) {
-          await getList(displayType)
-          setIsLoading(false)
-          if (displayType === 'snapshots') location.reload()
-          return
-        }
-
-        setSnapshotError(resultJson)
-      } catch (error) {
-        setSnapshotError({ message: 'Front end error while taking snapshot', error })
-      }
-    }
-
-    if (data?.snapshots.find((snapshot) => snapshot.name === normaliseSnapshotName(name))) {
-      showModal({
-        title: `A snapshot with this name already exists`,
-        message: `This will overwrite ${normaliseSnapshotName(name)}`,
-        onConfirm: doOperation,
+    setIsLoading(true)
+    try {
+      const resultJson = await postRequest({
+        url: getServerUrl('snapshot', {
+          action: 'take',
+          name: normaliseSnapshotName(name),
+          archive: displayType === 'archives',
+        }),
+        jsonBody: {
+          archive:
+            typeof archive === 'string'
+              ? archive
+              : archive === undefined
+              ? 'full'
+              : { from: archive, to: archiveEnd },
+        },
+        headers: { 'Content-Type': 'application/json' },
       })
-    } else doOperation()
+
+      if (resultJson.success) {
+        await getList(displayType)
+        setIsLoading(false)
+        if (displayType === 'snapshots') location.reload()
+        return
+      }
+
+      setSnapshotError(resultJson)
+    } catch (error) {
+      setSnapshotError({ message: 'Front end error while taking snapshot', error })
+    }
   }
 
   const useSnapshot = async (name: string) => {

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -215,7 +215,7 @@ const Snapshots: React.FC = () => {
     return (
       <>
         {data.snapshots.map(({ name, filename, timestamp, archive, size }) => (
-          <Table.Row key={`app_menu_${name}`}>
+          <Table.Row key={filename}>
             <Table.Cell colSpan={12} style={{ padding: 5 }}>
               <div className="flex-row-space-between" style={{ width: '100%', padding: 5 }}>
                 <div className="flex-row" style={{ gap: 10 }}>
@@ -279,7 +279,12 @@ const Snapshots: React.FC = () => {
                     name="trash alternate"
                     onClick={async () => {
                       await deleteSnapshot(filename)
-                      showToast({ title: 'Snapshot deleted', text: name })
+                      showToast({
+                        title: `${
+                          displayType === 'archives' ? 'Archive snapshot' : 'Snapshot'
+                        } deleted`,
+                        text: name,
+                      })
                     }}
                   />
                 </div>

--- a/src/containers/TemplateBuilder/Templates.tsx
+++ b/src/containers/TemplateBuilder/Templates.tsx
@@ -14,7 +14,7 @@ import {
 import { useRouter } from '../../utils/hooks/useRouter'
 import OperationContext, { TemplateOptions, useOperationState } from './shared/OperationContext'
 import TextIO from './shared/TextIO'
-import useGetTemplates, { Template, Templates, VersionObject } from './useGetTemplates'
+import useGetTemplates, { Template, Templates } from './useGetTemplates'
 import { useLanguageProvider } from '../../contexts/Localisation'
 import usePageTitle from '../../utils/hooks/usePageTitle'
 import config from '../../config'

--- a/src/containers/TemplateBuilder/shared/OperationContext.tsx
+++ b/src/containers/TemplateBuilder/shared/OperationContext.tsx
@@ -31,7 +31,6 @@ import {
   updateTemplateStage,
   deleteTemplate,
 } from './OperationContextHelpers'
-import { VersionObject } from '../useGetTemplates'
 import { TemplateState } from '../template/TemplateWrapper'
 
 type Error = { message: string; error: string }
@@ -128,7 +127,7 @@ const OperationContext: React.FC = ({ children }) => {
 
   const { isLoading, error } = innerState
   const renderExtra = () => (
-    <Modal open={!!isLoading || !!error} onClick={resetLoading} onClose={resetLoading}>
+    <Modal open={!!isLoading || !!error} onClose={resetLoading}>
       {error ? (
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           <Label size="large" color="red">

--- a/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
+++ b/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
@@ -269,7 +269,7 @@ export const importTemplate: ImportTemplateHelper =
       data.append('file', file)
 
       const result = await safeFetch(
-        getServerUrl('snapshot', { action: 'upload', name: snapshotName }),
+        getServerUrl('snapshot', { action: 'upload' }),
         data,
         setErrorAndLoadingState
       )

--- a/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
+++ b/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
@@ -269,7 +269,7 @@ export const importTemplate: ImportTemplateHelper =
       data.append('file', file)
 
       const result = await safeFetch(
-        getServerUrl('snapshot', { action: 'upload' }),
+        getServerUrl('snapshot', { action: 'upload', template: true }),
         data,
         setErrorAndLoadingState
       )

--- a/src/utils/helpers/endpoints/endpointUrlBuilder.ts
+++ b/src/utils/helpers/endpoints/endpointUrlBuilder.ts
@@ -114,6 +114,7 @@ const getServerUrl = (...args: ComplexEndpoint | BasicEndpoint | ['graphQL']): s
     case 'snapshot':
       const { action } = options as SnapshotEndpoint[1]
       const isArchive = 'archive' in options && options.archive
+      const isTemplate = 'template' in options && options.template
 
       if (action === 'list')
         return `${serverREST}${endpointPath}/list${isArchive ? '?archive=true' : ''}`
@@ -121,7 +122,8 @@ const getServerUrl = (...args: ComplexEndpoint | BasicEndpoint | ['graphQL']): s
       const name = 'name' in options ? options.name : null
       const optionsName = 'options' in options ? options.options : null
 
-      if (action === 'upload') return `${serverREST}${endpointPath}/upload`
+      if (action === 'upload')
+        return `${serverREST}${endpointPath}/upload${isTemplate ? '?template=true' : ''}`
 
       if (!name) throw new Error('Name parameter missing in snapshot endpoint query')
 

--- a/src/utils/helpers/endpoints/endpointUrlBuilder.ts
+++ b/src/utils/helpers/endpoints/endpointUrlBuilder.ts
@@ -120,13 +120,15 @@ const getServerUrl = (...args: ComplexEndpoint | BasicEndpoint | ['graphQL']): s
       const name = 'name' in options ? options.name : null
       const optionsName = 'options' in options ? options.options : null
 
+      if (action === 'upload') return `${serverREST}${endpointPath}/upload`
+
       if (!name) throw new Error('Name parameter missing in snapshot endpoint query')
 
       // "download" is direct download url
       if (action === 'download')
         return `${serverREST}${endpointPath}/files/${isArchive ? '_archives/' : ''}${name}.zip`
 
-      if (action === 'upload' || action === 'delete')
+      if (action === 'delete')
         return `${serverREST}${endpointPath}/${action}?name=${name}${
           isArchive ? '&archive=true' : ''
         }`

--- a/src/utils/helpers/endpoints/endpointUrlBuilder.ts
+++ b/src/utils/helpers/endpoints/endpointUrlBuilder.ts
@@ -112,7 +112,10 @@ const getServerUrl = (...args: ComplexEndpoint | BasicEndpoint | ['graphQL']): s
 
     case 'snapshot':
       const { action } = options as SnapshotEndpoint[1]
-      if (action === 'list') return `${serverREST}${endpointPath}/list`
+      const isArchive = 'archive' in options && options.archive
+
+      if (action === 'list')
+        return `${serverREST}${endpointPath}/list${isArchive ? '?archive=true' : ''}`
 
       const name = 'name' in options ? options.name : null
       const optionsName = 'options' in options ? options.options : null
@@ -120,15 +123,18 @@ const getServerUrl = (...args: ComplexEndpoint | BasicEndpoint | ['graphQL']): s
       if (!name) throw new Error('Name parameter missing in snapshot endpoint query')
 
       // "download" is direct download url
-      if (action === 'download') return `${serverREST}${endpointPath}/files/${name}.zip`
+      if (action === 'download')
+        return `${serverREST}${endpointPath}/files/${isArchive ? '_archives/' : ''}${name}.zip`
 
       if (action === 'upload' || action === 'delete')
-        return `${serverREST}${endpointPath}/${action}?name=${name}`
+        return `${serverREST}${endpointPath}/${action}?name=${name}${
+          isArchive ? '&archive=true' : ''
+        }`
 
       // Must be "take" or "use", which uses "options" file
       return `${serverREST}${endpointPath}/${action}?name=${name}${
         optionsName ? `&optionsName=${optionsName}` : ''
-      }`
+      }${isArchive ? '&archive=true' : ''}`
 
     case 'lookupTable': {
       let { action } = options as LookupTableEndpoint[1]

--- a/src/utils/helpers/endpoints/endpointUrlBuilder.ts
+++ b/src/utils/helpers/endpoints/endpointUrlBuilder.ts
@@ -12,6 +12,7 @@ import {
   RemoveLanguageEndpoint,
   GetApplicationDataEndpoint,
   SnapshotEndpoint,
+  ArchiveEndpoint,
 } from './types'
 
 const {
@@ -161,6 +162,10 @@ const getServerUrl = (...args: ComplexEndpoint | BasicEndpoint | ['graphQL']): s
       return `${serverREST}${endpointPath}?applicationId=${applicationId}${
         reviewId ? `&reviewId=${reviewId}` : ''
       }`
+
+    case 'archiveFiles':
+      const { days } = options as ArchiveEndpoint[1]
+      return `${serverREST}${endpointPath}?days=${days}`
 
     default:
       // "never" type ensures we will get a *compile-time* error if we are

--- a/src/utils/helpers/endpoints/types.ts
+++ b/src/utils/helpers/endpoints/types.ts
@@ -78,7 +78,8 @@ export type SnapshotEndpoint = [
   endpoint: 'snapshot',
   options:
     | { action: 'list'; archive?: boolean }
-    | { action: 'download' | 'upload' | 'delete'; name: string; archive?: boolean }
+    | { action: 'download' | 'delete'; name: string; archive?: boolean }
+    | { action: 'upload' }
     | { action: 'take' | 'use'; name: string; options?: string; archive?: boolean }
 ]
 

--- a/src/utils/helpers/endpoints/types.ts
+++ b/src/utils/helpers/endpoints/types.ts
@@ -77,9 +77,9 @@ export type RemoveLanguageEndpoint = [endpoint: 'removeLanguage', options: { cod
 export type SnapshotEndpoint = [
   endpoint: 'snapshot',
   options:
-    | { action: 'list' }
-    | { action: 'download' | 'upload' | 'delete'; name: string }
-    | { action: 'take' | 'use'; name: string; options?: string }
+    | { action: 'list'; archive?: boolean }
+    | { action: 'download' | 'upload' | 'delete'; name: string; archive?: boolean }
+    | { action: 'take' | 'use'; name: string; options?: string; archive?: boolean }
 ]
 
 export type LookupTableEndpoint = [

--- a/src/utils/helpers/endpoints/types.ts
+++ b/src/utils/helpers/endpoints/types.ts
@@ -79,7 +79,7 @@ export type SnapshotEndpoint = [
   options:
     | { action: 'list'; archive?: boolean }
     | { action: 'download' | 'delete'; name: string; archive?: boolean }
-    | { action: 'upload' }
+    | { action: 'upload'; template?: boolean }
     | { action: 'take' | 'use'; name: string; options?: string; archive?: boolean }
 ]
 

--- a/src/utils/helpers/endpoints/types.ts
+++ b/src/utils/helpers/endpoints/types.ts
@@ -83,6 +83,8 @@ export type SnapshotEndpoint = [
     | { action: 'take' | 'use'; name: string; options?: string; archive?: boolean }
 ]
 
+export type ArchiveEndpoint = [endpoint: 'archiveFiles', options: { days: number }]
+
 export type LookupTableEndpoint = [
   endpoint: 'lookupTable',
   options:
@@ -117,5 +119,6 @@ export type ComplexEndpoint =
   | EnableLanguageEndpoint
   | RemoveLanguageEndpoint
   | SnapshotEndpoint
+  | ArchiveEndpoint
   | LookupTableEndpoint
   | GetApplicationDataEndpoint

--- a/src/utils/helpers/utilityFunctions.ts
+++ b/src/utils/helpers/utilityFunctions.ts
@@ -73,7 +73,8 @@ export const constructOrObjectFilters = (filters: { [key: string]: string }[]) =
 export const fileSizeWithUnits = (size: number): string => {
   const sizeInKb = size / 1000
   if (sizeInKb < 1000) return `${sizeInKb} kB`
-  const sizeInMB = size / 1000000
-  if (sizeInKb < 100_000) return `${parseInt(String(sizeInMB * 10)) / 10} MB`
-  return `${parseInt(String(sizeInKb / 1000))} MB`
+  const sizeInMB = size / 1_000_000
+  if (sizeInKb < 1_000_000) return `${parseInt(String(sizeInMB * 10)) / 10} MB`
+  const sizeInGB = size / 1_000_000_000
+  return `${parseInt(String(sizeInGB * 100)) / 100} GB`
 }

--- a/src/utils/helpers/utilityFunctions.ts
+++ b/src/utils/helpers/utilityFunctions.ts
@@ -68,3 +68,12 @@ export const constructOrObjectFilters = (filters: { [key: string]: string }[]) =
     return { [filterKey]: { equalTo: filterValue } }
   }),
 })
+
+// Nicely formatted file sizes, e.g. 1000000 => "1MB"
+export const fileSizeWithUnits = (size: number): string => {
+  const sizeInKb = size / 1000
+  if (sizeInKb < 1000) return `${sizeInKb} kB`
+  const sizeInMB = size / 1000000
+  if (sizeInKb < 100_000) return `${parseInt(String(sizeInMB * 10)) / 10} MB`
+  return `${parseInt(String(sizeInKb / 1000))} MB`
+}


### PR DESCRIPTION
Fix https://github.com/openmsupply/conforma-server/discussions/1059 (detailed spec/discussion: https://github.com/openmsupply/conforma-server/discussions/1059)

Requires back-end branch from https://github.com/openmsupply/conforma-server/pull/1060

Quite a big face-lift and consolidation for the Snapshots page. It gives more useful stats about each snapshot, include the file size and the archive status:
<img width="734" alt="Screenshot 2023-07-26 at 12 05 21 PM" src="https://github.com/openmsupply/conforma-web-app/assets/5456533/61a728ba-ca78-4365-a3ec-c4971ba34de4">

**Archives**:
<img width="759" alt="Screenshot 2023-07-26 at 11 39 14 AM" src="https://github.com/openmsupply/conforma-web-app/assets/5456533/413c34f4-c58a-409c-af47-ae08ffc33fd1">

## Summary of changes
- Separate lists for normal Snapshot and "Archive" snapshots
- Show snapshot stats, including file size and archive info
- No need to add time-stamp to snapshot names -- it's automatically appended to downloads
- Creating new snapshot, can specify archive range (or "none" or "full")
- Manually trigger a file archive
- Removed the ability to overwrite a snapshot -- you have to create a new one (can use the same name though, but will have a different timestamp)
- Lots of internal logic to handle the back-end changes (see inline comments)
