### PR TITLE
#1068B File archive and template version improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-web-app",
-  "version": "0.5.6-0",
+  "version": "0.5.6-75",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conforma-web-app",
-  "version": "0.5.6-75",
+  "version": "0.5.6-76",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -328,7 +328,14 @@ const Snapshots: React.FC = () => {
             {snapshotError.message}
             <Icon name="close" onClick={resetLoading} />
           </Label>
-          <div style={{ margin: 20 }}>{snapshotError.error}</div>
+          <div style={{ margin: 20 }}>
+            {snapshotError.error.split('\n').map((line) => (
+              <>
+                <span>{line}</span>
+                <br />
+              </>
+            ))}
+          </div>
         </div>
       ) : (
         <Loader active>Loading</Loader>

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -305,7 +305,11 @@ const Snapshots: React.FC = () => {
         {hasChildren && (
           <div
             className="flex-row-start-center clickable"
-            onClick={() => {
+            onClick={(e: React.MouseEvent<HTMLElement>) => {
+              if (e.getModifierState('Meta') || e.getModifierState('Control')) {
+                setExpandedSnapshots([])
+                return
+              }
               if (expandedSnapshots.includes(name))
                 setExpandedSnapshots(expandedSnapshots.filter((el) => el !== name))
               else setExpandedSnapshots([...expandedSnapshots, name])

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -334,16 +334,20 @@ const Snapshots: React.FC = () => {
     if (!data) return null
     const nestedSnapshots = getNestedSnapshots(data.snapshots)
     return nestedSnapshots.map((snapshot) => (
-      <>
+      <React.Fragment key={snapshot.filename}>
         {renderSingleSnapshot(snapshot, snapshot.otherVersions.length > 0)}
         {expandedSnapshots.includes(snapshot.name) && (
-          <Table style={{ marginTop: -10, marginBottom: 0, paddingLeft: 20 }}>
-            <Table.Body>
-              {snapshot.otherVersions.map((snapshot) => renderSingleSnapshot(snapshot))}
-            </Table.Body>
-          </Table>
+          <Table.Row>
+            <Table.Cell style={{ background: 'transparent', paddingRight: 0 }}>
+              <Table style={{ marginTop: -14, marginBottom: -10 }}>
+                <Table.Body>
+                  {snapshot.otherVersions.map((snapshot) => renderSingleSnapshot(snapshot))}
+                </Table.Body>
+              </Table>
+            </Table.Cell>
+          </Table.Row>
         )}
-      </>
+      </React.Fragment>
     ))
   }
 
@@ -661,12 +665,11 @@ const getTotalSize = (
 ) => {
   if (!currentArchives) return null
   if (!archiveStart || archiveStart === 'none') return null
-  if (archiveStart === 'full')
-    return currentArchives.reduce((sum, archive) => sum + (archive?.totalFileSize ?? 0), 0)
+  const start = archiveStart === 'full' ? 0 : archiveStart ?? 0
   const end = archiveEnd ?? Infinity
 
   const includedArchives = currentArchives.filter(
-    (archive) => archive.timestamp >= archiveStart && archive.timestamp <= end
+    (archive) => archive.timestamp >= start && archive.timestamp <= end
   )
   if (includedArchives.some((archive) => !archive.totalFileSize)) return 'Unknown'
 

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -59,6 +59,7 @@ const Snapshots: React.FC = () => {
   const [displayType, setDisplayType] = useState<SnapshotType>(
     (query.type as SnapshotType) ?? 'snapshots'
   )
+  const [expandedSnapshots, setExpandedSnapshots] = useState<string[]>([])
   const [archive, setArchive] = useState<number | 'full' | 'none'>()
   const [archiveEnd, setArchiveEnd] = useState<number>()
   const [refetchData, setRefetchData] = useState(false)
@@ -213,106 +214,133 @@ const Snapshots: React.FC = () => {
     a.click()
   }
 
+  const renderSingleSnapshot = (
+    { name, filename, timestamp, archive, size }: SnapshotData,
+    hasChildren = false
+  ) => (
+    <Table.Row key={filename}>
+      <Table.Cell style={{ padding: 5 }}>
+        <div className="flex-row-space-between" style={{ width: '100%', padding: 5 }}>
+          <div className="flex-row" style={{ gap: 10 }}>
+            <strong>{name}</strong>
+            <span className="smaller-text">{size ? fileSizeWithUnits(size) : 'Size unknown'}</span>
+          </div>
+          <div className="flex-row" style={{ gap: 5 }}>
+            {displayType === 'snapshots' && (
+              <Icon
+                size="large"
+                className="clickable"
+                name="play circle"
+                onClick={() => {
+                  if (isProductionBuild)
+                    showModal({
+                      title: 'Are you sure?',
+                      message: `This will overwrite ALL existing data on: ${window.location.host}`,
+                      onConfirm: () => useSnapshot(filename),
+                    })
+                  else useSnapshot(filename)
+                }}
+              />
+            )}
+            <Icon
+              name="download"
+              size="large"
+              className="clickable blue"
+              onClick={async () => {
+                showToast({ title: 'Download started...', timeout: 2000 })
+                await downloadSnapshot(filename)
+                showToast({
+                  title: 'Download complete',
+                  text: `${displayType === 'archives' ? 'ARCHIVE_' : ''}${filename}`,
+                  timeout: 30000,
+                })
+              }}
+            />
+
+            <Icon
+              size="large"
+              className="clickable"
+              name="trash alternate"
+              onClick={async () => {
+                await deleteSnapshot(filename)
+                showToast({
+                  title: `${displayType === 'archives' ? 'Archive snapshot' : 'Snapshot'} deleted`,
+                  text: name,
+                })
+              }}
+            />
+          </div>
+        </div>
+        <div className="flex-row" style={{ gap: 10, padding: 5 }}>
+          <TextIO
+            text={DateTime.fromISO(timestamp).toLocaleString(DateTime.DATETIME_SHORT)}
+            title="Timestamp"
+            additionalStyles={{ margin: 0 }}
+          />
+          {archive && (
+            <div className="flex-row-start-center" style={{ gap: 5 }}>
+              {archive.type !== 'none' && (
+                <>
+                  <TextIO
+                    title={`Archive`}
+                    text={`${DateTime.fromISO(
+                      archive.from ?? ''
+                    ).toLocaleString()} – ${DateTime.fromISO(archive.to ?? '').toLocaleString()}`}
+                    additionalStyles={{ margin: 0 }}
+                  />
+                  <Tooltip
+                    message={`### Archives\n\nFrom: **${DateTime.fromISO(
+                      archive.from ?? ''
+                    ).toLocaleString(DateTime.DATETIME_MED)}**  \nTo: **${DateTime.fromISO(
+                      archive.to ?? ''
+                    ).toLocaleString(DateTime.DATETIME_MED)}**`}
+                    iconStyle={{ marginLeft: 0, height: 'auto' }}
+                  />
+                </>
+              )}
+              {renderArchiveLabel(archive)}
+            </div>
+          )}
+        </div>
+        {hasChildren && (
+          <div
+            className="flex-row-start-center clickable"
+            onClick={() => {
+              if (expandedSnapshots.includes(name))
+                setExpandedSnapshots(expandedSnapshots.filter((el) => el !== name))
+              else setExpandedSnapshots([...expandedSnapshots, name])
+            }}
+          >
+            <Icon
+              size="large"
+              name="dropdown"
+              style={{
+                transform: expandedSnapshots.includes(name) ? 'rotate(0deg)' : 'rotate(-90deg)',
+                transition: '0.2s',
+              }}
+            />
+            <p className="smaller-text">Show all</p>
+          </div>
+        )}
+      </Table.Cell>
+    </Table.Row>
+  )
+
   const renderSnapshotList = () => {
     if (!data) return null
-    return (
+    const nestedSnapshots = getNestedSnapshots(data.snapshots)
+    return nestedSnapshots.map((snapshot) => (
       <>
-        {data.snapshots.map(({ name, filename, timestamp, archive, size }) => (
-          <Table.Row key={filename}>
-            <Table.Cell colSpan={12} style={{ padding: 5 }}>
-              <div className="flex-row-space-between" style={{ width: '100%', padding: 5 }}>
-                <div className="flex-row" style={{ gap: 10 }}>
-                  <strong>{name}</strong>
-                  <span className="smaller-text">
-                    {size ? fileSizeWithUnits(size) : 'Size unknown'}
-                  </span>
-                </div>
-                <div className="flex-row" style={{ gap: 5 }}>
-                  {displayType === 'snapshots' && (
-                    <Icon
-                      size="large"
-                      className="clickable"
-                      name="play circle"
-                      onClick={() => {
-                        if (isProductionBuild)
-                          showModal({
-                            title: 'Are you sure?',
-                            message: `This will overwrite ALL existing data on: ${window.location.host}`,
-                            onConfirm: () => useSnapshot(filename),
-                          })
-                        else useSnapshot(filename)
-                      }}
-                    />
-                  )}
-                  <Icon
-                    name="download"
-                    size="large"
-                    className="clickable blue"
-                    onClick={async () => {
-                      showToast({ title: 'Download started...', timeout: 2000 })
-                      await downloadSnapshot(filename)
-                      showToast({
-                        title: 'Download complete',
-                        text: `${displayType === 'archives' ? 'ARCHIVE_' : ''}${filename}`,
-                        timeout: 30000,
-                      })
-                    }}
-                  />
-
-                  <Icon
-                    size="large"
-                    className="clickable"
-                    name="trash alternate"
-                    onClick={async () => {
-                      await deleteSnapshot(filename)
-                      showToast({
-                        title: `${
-                          displayType === 'archives' ? 'Archive snapshot' : 'Snapshot'
-                        } deleted`,
-                        text: name,
-                      })
-                    }}
-                  />
-                </div>
-              </div>
-              <div className="flex-row" style={{ gap: 10, padding: 5 }}>
-                <TextIO
-                  text={DateTime.fromISO(timestamp).toLocaleString(DateTime.DATETIME_SHORT)}
-                  title="Timestamp"
-                  additionalStyles={{ margin: 0 }}
-                />
-                {archive && (
-                  <div className="flex-row-start-center" style={{ gap: 5 }}>
-                    {archive.type !== 'none' && (
-                      <>
-                        <TextIO
-                          title={`Archive`}
-                          text={`${DateTime.fromISO(
-                            archive.from ?? ''
-                          ).toLocaleString()} – ${DateTime.fromISO(
-                            archive.to ?? ''
-                          ).toLocaleString()}`}
-                          additionalStyles={{ margin: 0 }}
-                        />
-                        <Tooltip
-                          message={`### Archives\n\nFrom: **${DateTime.fromISO(
-                            archive.from ?? ''
-                          ).toLocaleString(DateTime.DATETIME_MED)}**  \nTo: **${DateTime.fromISO(
-                            archive.to ?? ''
-                          ).toLocaleString(DateTime.DATETIME_MED)}**`}
-                          iconStyle={{ marginLeft: 0, height: 'auto' }}
-                        />
-                      </>
-                    )}
-                    {renderArchiveLabel(archive)}
-                  </div>
-                )}
-              </div>
-            </Table.Cell>
-          </Table.Row>
-        ))}
+        {renderSingleSnapshot(snapshot, snapshot.otherVersions.length > 0)}
+        {expandedSnapshots.includes(snapshot.name) && (
+          <Table style={{ marginTop: -10, marginBottom: 0, paddingLeft: 20 }}>
+            <Table.Body>
+              {snapshot.otherVersions.map((snapshot) => renderSingleSnapshot(snapshot))}
+            </Table.Body>
+          </Table>
+        )}
       </>
-    )
+    ))
   }
 
   const resetLoading = () => {
@@ -639,6 +667,16 @@ const getTotalSize = (
   if (includedArchives.some((archive) => !archive.totalFileSize)) return 'Unknown'
 
   return includedArchives.reduce((sum, archive) => sum + (archive.totalFileSize ?? 0), 0)
+}
+
+const getNestedSnapshots = (snapshots: SnapshotData[]) => {
+  const nestedSnapshots: (SnapshotData & { otherVersions: SnapshotData[] })[] = []
+  snapshots.forEach((snapshot) => {
+    const outer = nestedSnapshots.find((el) => el.name === snapshot.name)
+    if (outer) outer.otherVersions.push(snapshot)
+    else nestedSnapshots.push({ ...snapshot, otherVersions: [] })
+  })
+  return nestedSnapshots
 }
 
 export default Snapshots

--- a/src/containers/TemplateBuilder/template/General/General.tsx
+++ b/src/containers/TemplateBuilder/template/General/General.tsx
@@ -23,7 +23,7 @@ import { DateTime } from 'luxon'
 import { useRouter } from '../../../../utils/hooks/useRouter'
 import useConfirmationModal from '../../../../utils/hooks/useConfirmationModal'
 import { useToast } from '../../../../contexts/Toast'
-import { getVersionString, getTemplateVersionId } from '../helpers'
+import { getVersionString, getTemplateVersionId, isTemplateUnlocked } from '../helpers'
 
 const General: React.FC = () => {
   const { t } = useLanguageProvider()
@@ -31,7 +31,7 @@ const General: React.FC = () => {
   const { updateTemplate, deleteTemplate } = useOperationState()
   const { structure } = useApplicationState()
   const { template } = useTemplateState()
-  const { canEdit, isDraft } = template
+  const { canEdit, isDraft, applicationCount } = template
   const { refetch: refetchAvailable } = useGetTemplatesAvailableForCodeQuery({
     variables: { code: template.code },
   })
@@ -43,11 +43,15 @@ const General: React.FC = () => {
   const { ConfirmModal: DeleteConfirm, showModal: confirmDelete } = useConfirmationModal({
     type: 'warning',
   })
+  const { ConfirmModal: MakeAvailableConfirm, showModal: confirmMakeAvailable } =
+    useConfirmationModal({
+      type: 'warning',
+    })
 
   const canSetAvailable = template.status !== TemplateStatus.Available
 
   const canSetDraft =
-    canEdit &&
+    applicationCount === 0 &&
     !isDraft &&
     (template.applicationCount === 0 ||
       // Let us make changes to active templates while in "dev" mode
@@ -57,13 +61,23 @@ const General: React.FC = () => {
 
   return (
     <div className="flex-column-center-start">
+      <MakeAvailableConfirm />
       <div className="flex-row flex-gap-10">
         <ButtonWithFallback
           title={t('TEMPLATE_GEN_BUTTON_AVAILABLE')}
           disabledMessage={t('TEMPLATE_GEN_BUTTON_AVAILABLE_DISABLED')}
           disabled={!canSetAvailable}
           onClick={() => {
-            updateTemplate(template, { status: TemplateStatus.Available })
+            if (isTemplateUnlocked(template))
+              confirmMakeAvailable({
+                title: 'Make template available?',
+                message:
+                  'You are about to enable a template version that has not yet been committed. This is allowed, but you are recommended to commit first if you are about to enable it in a production environment.',
+                onConfirm: () => updateTemplate(template, { status: TemplateStatus.Available }),
+                confirmText: 'Make available now',
+                cancelText: 'Go back and commit version',
+              })
+            else updateTemplate(template, { status: TemplateStatus.Available })
           }}
         />
         <ButtonWithFallback
@@ -259,7 +273,7 @@ const General: React.FC = () => {
             </Table.Cell>
             <Table.Cell>
               <div className="flex-row-space-between-center">
-                {canEdit ? (
+                {isTemplateUnlocked(template) ? (
                   <>
                     <em>Not yet committed or exported</em>
                     <Button

--- a/src/containers/TemplateBuilder/template/General/General.tsx
+++ b/src/containers/TemplateBuilder/template/General/General.tsx
@@ -24,7 +24,6 @@ import { useRouter } from '../../../../utils/hooks/useRouter'
 import useConfirmationModal from '../../../../utils/hooks/useConfirmationModal'
 import { useToast } from '../../../../contexts/Toast'
 import { getVersionString, getTemplateVersionId, isTemplateUnlocked } from '../helpers'
-import te from 'date-fns/esm/locale/te/index.js'
 
 const General: React.FC = () => {
   const { t } = useLanguageProvider()

--- a/src/containers/TemplateBuilder/template/General/General.tsx
+++ b/src/containers/TemplateBuilder/template/General/General.tsx
@@ -24,6 +24,7 @@ import { useRouter } from '../../../../utils/hooks/useRouter'
 import useConfirmationModal from '../../../../utils/hooks/useConfirmationModal'
 import { useToast } from '../../../../contexts/Toast'
 import { getVersionString, getTemplateVersionId, isTemplateUnlocked } from '../helpers'
+import te from 'date-fns/esm/locale/te/index.js'
 
 const General: React.FC = () => {
   const { t } = useLanguageProvider()
@@ -51,6 +52,7 @@ const General: React.FC = () => {
   const canSetAvailable = template.status !== TemplateStatus.Available
 
   const canSetDraft =
+    isTemplateUnlocked(template) &&
     applicationCount === 0 &&
     !isDraft &&
     (template.applicationCount === 0 ||
@@ -72,7 +74,7 @@ const General: React.FC = () => {
               confirmMakeAvailable({
                 title: 'Make template available?',
                 message:
-                  'You are about to enable a template version that has not yet been committed. This is allowed, but you are recommended to commit first if you are about to enable it in a production environment.',
+                  'This will enable a template version that has not yet been committed. This is allowed, but it is recommended that you commit first if you are about to enable it in a production environment.',
                 onConfirm: () => updateTemplate(template, { status: TemplateStatus.Available }),
                 confirmText: 'Make available now',
                 cancelText: 'Go back and commit version',

--- a/src/containers/TemplateBuilder/useGetTemplates.ts
+++ b/src/containers/TemplateBuilder/useGetTemplates.ts
@@ -25,9 +25,9 @@ export type Template = {
 }
 export type Templates = {
   main: Template
-  applicationCount: number
-  numberOfTemplates: number
-  all: Template[]
+  totalApplicationCount: number
+  numberOfVersions: number
+  others: Template[]
 }[]
 
 const useGetTemplates = () => {
@@ -84,22 +84,28 @@ const useGetTemplates = () => {
         if (!holder)
           return templates.push({
             main: current,
-            applicationCount: current.applicationCount,
-            numberOfTemplates: 1,
-            all: [current],
+            totalApplicationCount: current.applicationCount,
+            numberOfVersions: 1,
+            others: [current],
           })
-        const { main, all } = holder
+        const { main, others } = holder
 
-        all.push(current)
         if (
           status === TemplateStatus.Available ||
           (main.status !== TemplateStatus.Available &&
             main.versionTimestamp < current.versionTimestamp)
         )
           holder.main = current
+        others.push(current)
 
-        holder.applicationCount += current.applicationCount
-        holder.numberOfTemplates = all.length
+        holder.totalApplicationCount += current.applicationCount
+        holder.numberOfVersions = others.length
+      })
+
+      // Don't include the "main" version in the "others", and order by most
+      // recent
+      templates.forEach((template) => {
+        template.others = template.others.filter(({ id }) => id !== template.main.id).reverse()
       })
 
       setTemplates(templates)


### PR DESCRIPTION
Fix https://github.com/openmsupply/conforma-server/issues/1068

As per original issue, the following fixes/improvements are implemented:

### File Archiving
- [x] Save total size of each archive in each archive's info.json, so this info can be displayed in front-end.
- [x] Bug when creating an archive snapshot when no upper range (happens after already creating one snapshot)
- [x] Group snapshots with the same name in collapsible row (like template versions)
  - [x] Use same technique on Templates page
  - [x] "Cmd" click collapses all
- [x] Display of missing archives not great (should be list):
![Screenshot 2023-08-04 at 5 11 13 PM](https://github.com/openmsupply/conforma-server/assets/5456533/786a16d6-1122-4799-a9e9-f7f37de19dee)

### Template versioning
- [x] "Commit this version" goes missing after making new version (something to do with "Status", not sure exactly)
- [x] Setting status = "Available" gives warning if version is not committed
- [x] Duplicating template should always set Status = DRAFT (Already done)
- [x] Once committed, shouldn't be able to set it to Draft


#### Collapsing snapshots (with the same name):
<img width="786" alt="Screenshot 2023-08-06 at 12 50 03 PM" src="https://github.com/openmsupply/conforma-web-app/assets/5456533/fa2cbb58-df86-4345-85bd-b2bceba223a5">

#### Improved template version collapsing:
<img width="1044" alt="Screenshot 2023-08-06 at 12 49 47 PM" src="https://github.com/openmsupply/conforma-web-app/assets/5456533/07e907d7-7d25-41a7-8637-03f829ba7a07">

- More consistent with Snapshots
- Easier to tell what's opened
- Can keep multiple expanded
- Doesn't duplicate the "main" version in the expanded list
- Shows combined application count when collapsed and per-version count when expanded

