### PR TITLE
#1561 DocumentModal -- other implementations

### DIFF
--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -440,7 +440,7 @@ _Interface for uploading documents or other files_
 - **subfolder**: `string` -- by default, files are uploaded into a subfolder with the name of the application serial. However, this can be over-ridden by specifying this parameter. This should rarely be required.
 - **showDescription**: `boolean` -- if `true`, an additional text input will be displayed alongside each file to allow the applicant to specify a description for each file. (default `false`)
 - **showFileRestrictions**: `boolean` -- will display the allowed file extensions and maximum size below the upload box (default: `true`)
-- **useDocumentModal**: `boolean` -- if `true`, will display documents (when clicked to view) in a modal overlay rather than opening in a new tab. Will fallback to global system preference.
+- **showDocumentModal**: `boolean` -- if `true`, will display documents (when clicked to view) in a modal overlay rather than opening in a new tab. Will fallback to global system preference.
 
 #### Response type
 

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -2400,6 +2400,10 @@ a:hover {
 *******************************/
 
 // These class names provided by the react-pdf package
+.react-pdf__Page {
+  margin-bottom: 30px;
+}
+
 .react-pdf__Page__textContent {
   border: 1px solid darkgrey;
   box-shadow: 5px 5px 5px 1px #ccc;

--- a/src/components/Review/DecisionPreview/PreviewItems.tsx
+++ b/src/components/Review/DecisionPreview/PreviewItems.tsx
@@ -4,6 +4,8 @@ import { useLanguageProvider } from '../../../contexts/Localisation'
 import MarkdownBlock from '../../../utils/helpers/semanticReactMarkdown'
 import { ActionQueueStatus } from '../../../utils/generated/graphql'
 import getServerUrl from '../../../utils/helpers/endpoints/endpointUrlBuilder'
+import { usePrefs } from '../../../contexts/SystemPrefs'
+import { DocumentModal, handleFile } from '../../common/DocumentModal/DocumentModal'
 
 interface ResultCommon {
   status: ActionQueueStatus
@@ -48,18 +50,33 @@ const NotificationPreview = ({ item }: { item: NotificationPreviewData }) => {
 }
 
 const DocumentPreview = ({ item }: { item: DocumentPreviewData }) => {
+  const {
+    preferences: { useDocumentModal },
+  } = usePrefs()
+  const [open, setOpen] = useState(false)
+  const { displayString, fileId } = item
+  const fileUrl = getServerUrl('file', { fileId })
+  const thumbnailUrl = getServerUrl('file', { fileId, thumbnail: true })
+
   return (
-    <div className="item document-preview">
-      <Image
-        src={getServerUrl('file', { fileId: item.fileId, thumbnail: true })}
-        style={{ maxHeight: 50 }}
-      />
-      <p>
-        <a href={getServerUrl('file', { fileId: item.fileId })} target="_blank">
-          {item.displayString}
-        </a>
-      </p>
-    </div>
+    <>
+      {useDocumentModal && (
+        <DocumentModal
+          url={fileUrl}
+          filename={displayString}
+          open={open}
+          onClose={() => setOpen(false)}
+          preventDownload
+        />
+      )}
+      <div
+        className="item document-preview"
+        onClick={() => handleFile(useDocumentModal, fileUrl, displayString, () => setOpen(true))}
+      >
+        <Image src={thumbnailUrl} className="clickable" style={{ maxHeight: 50 }} />
+        <p className="clickable link-style">{displayString}</p>
+      </div>
+    </>
   )
 }
 

--- a/src/components/Review/DecisionPreview/PreviewItems.tsx
+++ b/src/components/Review/DecisionPreview/PreviewItems.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from 'react'
 import { Icon, Accordion, Image } from 'semantic-ui-react'
 import { useLanguageProvider } from '../../../contexts/Localisation'
+import { useDocumentModal } from '../../../utils/hooks/useDocumentModal'
 import MarkdownBlock from '../../../utils/helpers/semanticReactMarkdown'
 import { ActionQueueStatus } from '../../../utils/generated/graphql'
 import getServerUrl from '../../../utils/helpers/endpoints/endpointUrlBuilder'
-import { usePrefs } from '../../../contexts/SystemPrefs'
-import { DocumentModal, handleFile } from '../../common/DocumentModal/DocumentModal'
 
 interface ResultCommon {
   status: ActionQueueStatus
@@ -50,29 +49,15 @@ const NotificationPreview = ({ item }: { item: NotificationPreviewData }) => {
 }
 
 const DocumentPreview = ({ item }: { item: DocumentPreviewData }) => {
-  const {
-    preferences: { useDocumentModal },
-  } = usePrefs()
-  const [open, setOpen] = useState(false)
   const { displayString, fileId } = item
   const fileUrl = getServerUrl('file', { fileId })
   const thumbnailUrl = getServerUrl('file', { fileId, thumbnail: true })
+  const { DocumentModal, handleFile } = useDocumentModal({ filename: displayString, fileUrl })
 
   return (
     <>
-      {useDocumentModal && (
-        <DocumentModal
-          url={fileUrl}
-          filename={displayString}
-          open={open}
-          onClose={() => setOpen(false)}
-          preventDownload
-        />
-      )}
-      <div
-        className="item document-preview"
-        onClick={() => handleFile(useDocumentModal, fileUrl, displayString, () => setOpen(true))}
-      >
+      {DocumentModal}
+      <div className="item document-preview" onClick={handleFile}>
         <Image src={thumbnailUrl} className="clickable" style={{ maxHeight: 50 }} />
         <p className="clickable link-style">{displayString}</p>
       </div>

--- a/src/components/common/DocumentModal/DocumentModal.tsx
+++ b/src/components/common/DocumentModal/DocumentModal.tsx
@@ -11,7 +11,7 @@ interface DocumentModalProps {
   filename: string
   url: string
   open: boolean
-  setOpen: (open: boolean) => void
+  onClose: () => void
   cachedFile?: File
 }
 
@@ -21,7 +21,7 @@ export const DocumentModal: React.FC<DocumentModalProps> = ({
   filename,
   url,
   open,
-  setOpen,
+  onClose,
   cachedFile,
 }: DocumentModalProps) => {
   const { t } = useLanguageProvider()
@@ -51,8 +51,7 @@ export const DocumentModal: React.FC<DocumentModalProps> = ({
     <Modal
       closeIcon
       open={open}
-      onOpen={() => setOpen(true)}
-      onClose={() => setOpen(false)}
+      onClose={() => onClose()}
       style={{
         width: fileType === 'pdf' ? contentWidth : 'unset',
         marginLeft: 15,
@@ -159,5 +158,23 @@ const getFileType = (filename: string): FileType => {
       return 'image'
     default:
       return 'other'
+  }
+}
+
+// Method for File displays to handle opening the selected file. Considers the
+// "useDocumentModal" preference and the file type to determine what to do.
+export const handleFile = (
+  shouldUseDocumentModal: boolean,
+  filename: string,
+  fileUrl: string,
+  modalOpenMethod: () => void
+) => {
+  // Display in Modal
+  if (shouldUseDocumentModal) modalOpenMethod()
+  else {
+    // Force download
+    if (getFileType(filename) === 'other') downloadFile(fileUrl, filename)
+    // Open in new tab
+    else window.open(fileUrl, '_blank')
   }
 }

--- a/src/components/common/DocumentModal/DocumentModal.tsx
+++ b/src/components/common/DocumentModal/DocumentModal.tsx
@@ -13,6 +13,7 @@ interface DocumentModalProps {
   open: boolean
   onClose: () => void
   cachedFile?: File
+  preventDownload?: boolean
 }
 
 type FileType = 'pdf' | 'image' | 'other'
@@ -23,9 +24,10 @@ export const DocumentModal: React.FC<DocumentModalProps> = ({
   open,
   onClose,
   cachedFile,
+  preventDownload,
 }: DocumentModalProps) => {
   const { t } = useLanguageProvider()
-  const [numPages, setNumPages] = useState(null)
+  const [numPages, setNumPages] = useState(0)
   const [currentPage, setCurrentPage] = useState(1)
   const [pageInput, setPageInput] = useState(1)
   const dimensions = useWindowDimensions()
@@ -62,7 +64,7 @@ export const DocumentModal: React.FC<DocumentModalProps> = ({
         <div className="flex-row-space-between-center-wrap" style={{ width: '95%', gap: 10 }}>
           <span style={{ maxWidth: 500 }}>{filename}</span>
           <div className="flex-row-start-center" style={{ gap: 5 }}>
-            {fileType === 'pdf' && (
+            {fileType === 'pdf' && numPages > 1 && (
               <div
                 className="flex-row-start-center"
                 style={{ gap: 10, fontSize: '1rem', fontWeight: 'normal', marginRight: 15 }}
@@ -81,7 +83,7 @@ export const DocumentModal: React.FC<DocumentModalProps> = ({
                 <span className="slightly-smaller-text"> of {numPages}</span>
               </div>
             )}
-            {fileType !== 'other' && (
+            {fileType !== 'other' && !preventDownload && (
               <>
                 <a href={url} target="_blank">
                   <Icon className="clickable" name="external alternate" />

--- a/src/components/common/DocumentModal/DocumentModal.tsx
+++ b/src/components/common/DocumentModal/DocumentModal.tsx
@@ -99,7 +99,7 @@ export const DocumentModal: React.FC<DocumentModalProps> = ({
           </div>
         </div>
       </Modal.Header>
-      <ModalContent style={{ maxHeight: '75vh', overflow: 'auto' }}>
+      <ModalContent style={{ maxHeight: '80vh', overflow: 'auto' }}>
         {fileType === 'pdf' && (
           <Document
             file={cachedFile ?? url}

--- a/src/containers/Review/documents/DocumentsTab.tsx
+++ b/src/containers/Review/documents/DocumentsTab.tsx
@@ -5,12 +5,17 @@ import { useGetApplicationDocsQuery } from '../../../utils/generated/graphql'
 import { FullStructure } from '../../../utils/types'
 import { useLanguageProvider } from '../../../contexts/Localisation'
 import { DateTime } from 'luxon'
+import { usePrefs } from '../../../contexts/SystemPrefs'
 import getServerUrl from '../../../utils/helpers/endpoints/endpointUrlBuilder'
+import { DocumentModal } from '../../../components/common/DocumentModal/DocumentModal'
 
 const DocumentsTab: React.FC<{
   structure: FullStructure
 }> = ({ structure: fullStructure }) => {
   const { t } = useLanguageProvider()
+  const {
+    preferences: { useDocumentModal },
+  } = usePrefs()
 
   const { data, loading, error } = useGetApplicationDocsQuery({
     variables: { applicationSerial: fullStructure.info.serial },

--- a/src/containers/Review/notes/NewCommentForm.tsx
+++ b/src/containers/Review/notes/NewCommentForm.tsx
@@ -6,13 +6,15 @@ import reactStringReplace from 'react-string-replace'
 import { TranslateMethod, useLanguageProvider } from '../../../contexts/Localisation'
 import useNotesMutations from '../../../utils/hooks/useNotesMutations'
 import { NotesState } from './NotesTab'
+import { SimpleCacheReturn } from '../../../utils/hooks/useSimpleCache'
 
 const NewCommentForm: React.FC<{
   structure: FullStructure
   state: NotesState
   setState: (state: NotesState) => void
   refetchNotes: Function
-}> = ({ structure, state, setState, refetchNotes }) => {
+  fileCache: SimpleCacheReturn<File>
+}> = ({ structure, state, setState, refetchNotes, fileCache }) => {
   const { t } = useLanguageProvider()
   const {
     userState: { currentUser },
@@ -33,6 +35,7 @@ const NewCommentForm: React.FC<{
     }
     await submit(currentUser as User, structure, comment, files)
     setState({ ...state, showForm: false, comment: '', files: [] })
+    files.forEach((file) => fileCache.addToCache(file.name, file))
   }
 
   const handleFiles = (e: any) => {

--- a/src/containers/Review/notes/NotesTab.tsx
+++ b/src/containers/Review/notes/NotesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import {
   Button,
   Checkbox,
@@ -20,9 +20,8 @@ import Markdown from '../../../utils/helpers/semanticReactMarkdown'
 import NewCommentForm from './NewCommentForm'
 import useNotesMutations from '../../../utils/hooks/useNotesMutations'
 import getServerUrl from '../../../utils/helpers/endpoints/endpointUrlBuilder'
-import { DocumentModal, handleFile } from '../../../components/common/DocumentModal/DocumentModal'
-import { SimpleCacheReturn, useSimpleCache } from '../../../utils/hooks/useSimpleCache'
-import { usePrefs } from '../../../contexts/SystemPrefs'
+import { useSimpleCache } from '../../../utils/hooks/useSimpleCache'
+import { useDocumentModal } from '../../../utils/hooks/useDocumentModal'
 
 const COMMENT_DELETION_LIMIT = 5 // minutes
 
@@ -138,7 +137,15 @@ const NotesTab: React.FC<{
                     }}
                   />
                 </div>
-                <FilesDisplay files={note.files.nodes as FileData[]} fileCache={fileCache} />
+                <div className="file-row">
+                  {note.files.nodes.map((file) => (
+                    <FileDisplay
+                      file={file as FileData}
+                      cachedFile={fileCache.getFromCache(file?.uniqueId ?? '')}
+                      key={file?.uniqueId}
+                    />
+                  ))}
+                </div>
                 <div className="note-footer-row">
                   <p className="tiny-bit-smaller-text">
                     <strong>{note.user?.fullName}</strong>
@@ -186,46 +193,31 @@ const NotesTab: React.FC<{
 
 export default NotesTab
 
-const FilesDisplay: React.FC<{ files: FileData[]; fileCache: SimpleCacheReturn<File> }> = ({
-  files,
-  fileCache,
-}) => {
-  if (files.length === 0) return null
-  const {
-    preferences: { useDocumentModal },
-  } = usePrefs()
-  const [openFile, setOpenFile] = useState<number>()
+const FileDisplay: React.FC<{
+  file: FileData
+  cachedFile?: File
+}> = ({ file, cachedFile }) => {
+  const { uniqueId, originalFilename } = file
+  const fileUrl = getServerUrl('file', { fileId: uniqueId })
+  const thumbnailUrl = getServerUrl('file', { fileId: uniqueId, thumbnail: true })
+
+  const { DocumentModal, handleFile } = useDocumentModal({
+    filename: originalFilename,
+    fileUrl,
+    cachedFile,
+  })
 
   return (
-    <div className="file-row">
-      {files.map((file: FileData, index: number) => {
-        const { uniqueId, originalFilename } = file
-        const fileUrl = getServerUrl('file', { fileId: uniqueId })
-        const thumbnailUrl = getServerUrl('file', { fileId: uniqueId, thumbnail: true })
-        const docOpen = () =>
-          handleFile(useDocumentModal, originalFilename, fileUrl, () => setOpenFile(index))
-        return (
-          <div className="file-container" key={file.uniqueId}>
-            {useDocumentModal && (
-              <DocumentModal
-                url={fileUrl}
-                filename={originalFilename}
-                open={index === openFile}
-                onClose={() => setOpenFile(undefined)}
-                cachedFile={fileCache.getFromCache(originalFilename)}
-              />
-            )}
-            <Image src={thumbnailUrl} className="clickable" onClick={docOpen} />
-            <p
-              style={{ wordBreak: 'break-word' }}
-              className="clickable link-style tiny-bit-smaller-text"
-              onClick={docOpen}
-            >
-              {file.originalFilename}
-            </p>
-          </div>
-        )
-      })}
+    <div className="file-container" key={file.uniqueId}>
+      {DocumentModal}
+      <Image src={thumbnailUrl} className="clickable" onClick={handleFile} />
+      <p
+        style={{ wordBreak: 'break-word' }}
+        className="clickable link-style tiny-bit-smaller-text"
+        onClick={handleFile}
+      >
+        {file.originalFilename}
+      </p>
     </div>
   )
 }

--- a/src/contexts/Localisation.tsx
+++ b/src/contexts/Localisation.tsx
@@ -271,6 +271,8 @@ const getTranslation = (
     } else substitutions = {}
   }
 
+  console.log('substitutions', substitutions)
+
   // "{{count}}" is a special replacement, where an alternative string can be
   // provided for certain numbers, usually a single value (1).
   if ('count' in substitutions) {

--- a/src/contexts/SystemPrefs.tsx
+++ b/src/contexts/SystemPrefs.tsx
@@ -10,7 +10,7 @@ interface Preferences {
   brandLogoFileId?: string
   brandLogoOnDarkFileId?: string
   defaultListFilters?: string[]
-  useDocumentModal: boolean
+  showDocumentModal: boolean
   googleAnalyticsId?: string
   siteHost?: string
   style?: { headerBgColor?: string }
@@ -24,7 +24,7 @@ interface PrefsState {
 }
 
 const defaultPrefs: Preferences = {
-  useDocumentModal: false,
+  showDocumentModal: false,
 }
 
 interface PrefsContext extends PrefsState {

--- a/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
+++ b/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
@@ -75,8 +75,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const fileInputRef = useRef<any>(null)
   // FileCache is to store the actual file contents after uploading, so when the
   // user previews it again they don't have to wait for it to re-download
-  const { cache, addToCache, removeFromCache, getFromCache } = useSimpleCache<File>()
-  // const [fileCache, setFileCache] = useState<Record<string, File>>({})
+  const { addToCache, removeFromCache, getFromCache } = useSimpleCache<File>()
 
   useEffect(() => {
     // Set response to null if no files

--- a/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
+++ b/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
@@ -53,7 +53,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     fileExtensions,
     fileSizeLimit,
     default: defaultValue,
-    useDocumentModal = preferences.useDocumentModal,
+    showDocumentModal = preferences.showDocumentModal,
     showDescription = false,
     showFileRestrictions = true,
     ...fileOptions
@@ -227,7 +227,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
                 file={file}
                 onDelete={handleDelete}
                 updateDescription={handleUpdateDescription}
-                shouldUseDocumentModal={useDocumentModal}
+                showDocumentModal={showDocumentModal}
                 cachedFile={getFromCache(file?.fileData?.uniqueId ?? '')}
               />
             ) : (
@@ -235,7 +235,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
                 key={file.key}
                 file={file}
                 onDelete={handleDelete}
-                shouldUseDocumentModal={useDocumentModal}
+                showDocumentModal={showDocumentModal}
                 cachedFile={getFromCache(file?.fileData?.uniqueId ?? '')}
               />
             )

--- a/src/formElementPlugins/fileUpload/src/SummaryView.tsx
+++ b/src/formElementPlugins/fileUpload/src/SummaryView.tsx
@@ -7,7 +7,7 @@ import { FileInfo } from './ApplicationView'
 
 const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, response }) => {
   const { preferences } = usePrefs()
-  const { label, description, useDocumentModal = preferences.useDocumentModal } = parameters
+  const { label, description, useDocumentModal = preferences.showDocumentModal } = parameters
   return (
     <Form.Field required={parameters.isRequired}>
       {label && (
@@ -22,7 +22,7 @@ const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, respons
             <FileDisplay
               key={file.uniqueId}
               file={{ filename: file.filename, fileData: file } as FileInfo}
-              shouldUseDocumentModal={useDocumentModal}
+              showDocumentModal={useDocumentModal}
             />
           ))}
       </List>

--- a/src/formElementPlugins/fileUpload/src/components/FileDisplay.tsx
+++ b/src/formElementPlugins/fileUpload/src/components/FileDisplay.tsx
@@ -1,11 +1,8 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { Icon, Grid, List, Image, Message, Loader } from 'semantic-ui-react'
-import {
-  DocumentModal,
-  handleFile,
-} from '../../../../components/common/DocumentModal/DocumentModal'
 import { useLanguageProvider } from '../../../../contexts/Localisation'
 import getServerUrl from '../../../../utils/helpers/endpoints/endpointUrlBuilder'
+import { useDocumentModal } from '../../../../utils/hooks/useDocumentModal'
 import { FileInfo } from '../ApplicationView'
 import prefs from '../../config.json'
 import './styles.css'
@@ -13,41 +10,35 @@ import './styles.css'
 export interface FileDisplayProps {
   file: FileInfo
   onDelete?: (key: string) => void
-  shouldUseDocumentModal: boolean
+  showDocumentModal: boolean
   cachedFile?: File
 }
 
 export const FileDisplay = ({
   file,
   onDelete,
-  shouldUseDocumentModal,
+  showDocumentModal,
   cachedFile,
 }: FileDisplayProps) => {
   const { getPluginTranslator } = useLanguageProvider()
   const t = getPluginTranslator('fileUpload')
   const { key, loading, error, errorMessage, filename, fileData } = file
-  const [open, setOpen] = useState(false)
 
   const fileUrl = fileData ? getServerUrl('file', { fileId: fileData.uniqueId }) : ''
   const thumbnailUrl = fileData
     ? getServerUrl('file', { fileId: fileData.uniqueId, thumbnail: true })
     : ''
 
-  const docOpen = () => {
-    handleFile(shouldUseDocumentModal, fileData?.filename ?? '', fileUrl, () => setOpen(true))
-  }
+  const { DocumentModal, handleFile } = useDocumentModal({
+    filename,
+    fileUrl,
+    showDocumentModal,
+    cachedFile,
+  })
 
   return (
     <List.Item className="file-item" style={{ position: 'relative', maxWidth: 150 }}>
-      {shouldUseDocumentModal && (
-        <DocumentModal
-          filename={filename}
-          url={fileUrl}
-          open={open}
-          onClose={() => setOpen(false)}
-          cachedFile={cachedFile}
-        />
-      )}
+      {DocumentModal}
       <Grid verticalAlign="top" celled style={{ boxShadow: 'none' }}>
         {error && (
           <>
@@ -83,7 +74,7 @@ export const FileDisplay = ({
               <Image
                 src={thumbnailUrl}
                 className="clickable"
-                onClick={docOpen}
+                onClick={handleFile}
                 style={{ maxHeight: prefs.applicationViewThumbnailHeight }}
               />
             </Grid.Row>
@@ -91,7 +82,7 @@ export const FileDisplay = ({
               <p
                 style={{ wordBreak: 'break-word' }}
                 className="clickable link-style tiny-bit-smaller-text"
-                onClick={docOpen}
+                onClick={() => handleFile()}
               >
                 {filename}
               </p>

--- a/src/formElementPlugins/fileUpload/src/components/FileDisplay.tsx
+++ b/src/formElementPlugins/fileUpload/src/components/FileDisplay.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react'
 import { Icon, Grid, List, Image, Message, Loader } from 'semantic-ui-react'
-import { DocumentModal } from '../../../../components/common/DocumentModal/DocumentModal'
+import {
+  DocumentModal,
+  handleFile,
+} from '../../../../components/common/DocumentModal/DocumentModal'
 import { useLanguageProvider } from '../../../../contexts/Localisation'
 import getServerUrl from '../../../../utils/helpers/endpoints/endpointUrlBuilder'
 import { FileInfo } from '../ApplicationView'
@@ -31,8 +34,7 @@ export const FileDisplay = ({
     : ''
 
   const docOpen = () => {
-    if (shouldUseDocumentModal) setOpen(true)
-    else window.open(fileUrl, '_blank')
+    handleFile(shouldUseDocumentModal, fileData?.filename ?? '', fileUrl, () => setOpen(true))
   }
 
   return (
@@ -42,7 +44,7 @@ export const FileDisplay = ({
           filename={filename}
           url={fileUrl}
           open={open}
-          setOpen={setOpen}
+          onClose={() => setOpen(false)}
           cachedFile={cachedFile}
         />
       )}

--- a/src/formElementPlugins/fileUpload/src/components/FileDisplayWIthDescription.tsx
+++ b/src/formElementPlugins/fileUpload/src/components/FileDisplayWIthDescription.tsx
@@ -42,7 +42,7 @@ export const FileDisplayWithDescription = ({
             filename={filename}
             url={fileUrl}
             open={open}
-            setOpen={setOpen}
+            onClose={() => setOpen(false)}
             cachedFile={cachedFile}
           />
         )}

--- a/src/formElementPlugins/fileUpload/src/components/FileDisplayWIthDescription.tsx
+++ b/src/formElementPlugins/fileUpload/src/components/FileDisplayWIthDescription.tsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react'
 import { Icon, Grid, List, Image, Message, Loader, Input } from 'semantic-ui-react'
 import getServerUrl from '../../../../utils/helpers/endpoints/endpointUrlBuilder'
 import { useLanguageProvider } from '../../../../contexts/Localisation'
+import { useDocumentModal } from '../../../../utils/hooks/useDocumentModal'
 import { FileDisplayProps } from './FileDisplay'
 import prefs from '../../config.json'
-import { DocumentModal } from '../../../../components/common/DocumentModal/DocumentModal'
 
 interface FileDisplayDescriptionProps extends FileDisplayProps {
   description?: string
@@ -15,13 +15,12 @@ export const FileDisplayWithDescription = ({
   file,
   onDelete,
   updateDescription,
-  shouldUseDocumentModal,
+  showDocumentModal,
   cachedFile,
 }: FileDisplayDescriptionProps) => {
   const { getPluginTranslator } = useLanguageProvider()
   const t = getPluginTranslator('fileUpload')
   const { loading, error, errorMessage, filename, fileData, key } = file
-  const [open, setOpen] = useState(false)
   const [description, setDescription] = useState<string>(fileData?.description ?? '')
 
   const fileUrl = fileData ? getServerUrl('file', { fileId: fileData.uniqueId }) : ''
@@ -29,23 +28,17 @@ export const FileDisplayWithDescription = ({
     ? getServerUrl('file', { fileId: fileData.uniqueId, thumbnail: true })
     : ''
 
-  const docOpen = () => {
-    if (shouldUseDocumentModal) setOpen(true)
-    else window.open(fileUrl, '_blank')
-  }
+  const { DocumentModal, handleFile } = useDocumentModal({
+    filename,
+    fileUrl,
+    showDocumentModal,
+    cachedFile,
+  })
 
   return (
     <List.Item>
       <div style={{ display: 'flex', gap: 20, alignItems: 'center', paddingRight: 20 }}>
-        {shouldUseDocumentModal && (
-          <DocumentModal
-            filename={filename}
-            url={fileUrl}
-            open={open}
-            onClose={() => setOpen(false)}
-            cachedFile={cachedFile}
-          />
-        )}
+        {DocumentModal}
         <Grid
           verticalAlign="top"
           celled
@@ -86,7 +79,7 @@ export const FileDisplayWithDescription = ({
                 <Image
                   src={thumbnailUrl}
                   className="clickable"
-                  onClick={docOpen}
+                  onClick={handleFile}
                   style={{ maxHeight: prefs.applicationViewThumbnailHeight }}
                 />
               </Grid.Row>
@@ -94,7 +87,7 @@ export const FileDisplayWithDescription = ({
                 <p
                   style={{ wordBreak: 'break-word' }}
                   className="clickable link-style slightly-smaller-text"
-                  onClick={docOpen}
+                  onClick={handleFile}
                 >
                   {filename}
                 </p>

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -157,6 +157,8 @@ export default {
   DEFAULT_TEMPLATE_CATEGORY_TITLE: 'General',
   DEFAULT_TEMPLATE_CATEGORY_ICON: 'globe',
   DOCUMENT_VIEW_NO_PREVIEW: 'No preview available. Please download to view file.',
+  DOCUMENT_VIEW_PAGE_JUMP: 'Jump to page',
+  DOCUMENT_VIEW_TOTAL_PAGES: 'Total pages: {{numPages}}',
   ERROR_APPLICATION_CREATE: 'Problem loading application creation page',
   ERROR_APPLICATION_DELETE: 'Problem deleting application',
   ERROR_APPLICATION_PAGE: 'Problem loading application',

--- a/src/utils/hooks/useSimpleCache.ts
+++ b/src/utils/hooks/useSimpleCache.ts
@@ -1,3 +1,8 @@
+/**
+ * A very simple key-value store. Currently used to cache recently uploaded
+ * files so they can be retrieved easily without re-downloading them.
+ */
+
 import { useState } from 'react'
 
 type SimpleCache<T> = Record<string, T>

--- a/src/utils/hooks/useSimpleCache.ts
+++ b/src/utils/hooks/useSimpleCache.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+
+type SimpleCache<T> = Record<string, T>
+
+export const useSimpleCache = <T>(): SimpleCacheReturn<T> => {
+  const [cache, setCache] = useState<SimpleCache<T>>({})
+
+  const addToCache = (key: string, value: T) => {
+    setCache((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const removeFromCache = (key: string) =>
+    setCache((current) => {
+      const newCache = { ...current }
+      delete newCache[key]
+      return newCache
+    })
+
+  const getFromCache = (key: string) => (key in cache ? cache[key] : undefined)
+
+  return { cache, addToCache, removeFromCache, getFromCache }
+}
+
+export type SimpleCacheReturn<T> = {
+  cache: SimpleCache<T>
+  addToCache: (key: string, value: T) => void
+  removeFromCache: (key: string) => void
+  getFromCache: (key: string) => T | undefined
+}


### PR DESCRIPTION
Fix #1561 

Added the document modal for:
- "Notes" tab (review page)
- "Documents" tab (review page)
- Previews (I know we said we would probably not do this one, but it actually looks pretty good and it was easy, so.._)

Some other improvements:
- made a generic "SimpleCache" hook which can be used by both the "Notes" implementation and the previous PR's form elements. As explained in comments, this means that a user can view a document they've just added without having to re-download it (which can be quite slow with big docs on slower systems).
- a generic "File handler" for opening files, which is used in each implementation. It handles the logic of whether the modal should be used, considers the file type, and acts accordingly (i.e. either opens the modal, opens in new tab, or downloads immediately)

See inline comment for further detail.