### PR TITLE
#1570 Mobile table header/sort bar

### DIFF
--- a/semantic/src/site/modules/dropdown.overrides
+++ b/semantic/src/site/modules/dropdown.overrides
@@ -1,3 +1,9 @@
 /*******************************
         User Overrides
 *******************************/
+
+@media only screen and (max-width: @largestMobileScreen) {
+  .ui.selection.dropdown .menu {
+    max-height: 50vh;
+  }
+}

--- a/src/components/List/ApplicationsList.tsx
+++ b/src/components/List/ApplicationsList.tsx
@@ -5,6 +5,7 @@ import { useDeleteApplicationMutation } from '../../utils/generated/graphql'
 import { ApplicationListRow, ColumnDetails, SortQuery } from '../../utils/types'
 import Loading from '../Loading'
 import { TableCellMobileLabelWrapper } from '../../utils/tables/TableCellMobileLabelWrapper'
+import { useViewport } from '../../contexts/ViewportState'
 
 interface ApplicationsListProps {
   columns: ColumnDetails[]
@@ -24,27 +25,30 @@ const ApplicationsList: React.FC<ApplicationsListProps> = ({
   refetch,
 }) => {
   const { t } = useLanguageProvider()
+  const { isMobile } = useViewport()
   return (
     <>
       <Table sortable stackable selectable>
-        <Table.Header>
-          <Table.Row>
-            {columns.map(({ headerName, headerDetail, sortName }, index) => (
-              <Table.HeaderCell
-                key={`ApplicationList-header-${headerName}-${index}`}
-                sorted={sortName && sortColumn === sortName ? sortDirection : undefined}
-                onClick={() => handleSort(sortName)}
-                colSpan={index === columns.length - 1 ? 2 : 1} // Set last column to fill last column (expansion)
-              >
-                {headerDetail ? (
-                  <Popup size="tiny" content={headerDetail} trigger={<span>{headerName}</span>} />
-                ) : (
-                  headerName
-                )}
-              </Table.HeaderCell>
-            ))}
-          </Table.Row>
-        </Table.Header>
+        {!isMobile && (
+          <Table.Header>
+            <Table.Row>
+              {columns.map(({ headerName, headerDetail, sortName }, index) => (
+                <Table.HeaderCell
+                  key={`ApplicationList-header-${headerName}-${index}`}
+                  sorted={sortName && sortColumn === sortName ? sortDirection : undefined}
+                  onClick={() => handleSort(sortName)}
+                  colSpan={index === columns.length - 1 ? 2 : 1} // Set last column to fill last column (expansion)
+                >
+                  {headerDetail ? (
+                    <Popup size="tiny" content={headerDetail} trigger={<span>{headerName}</span>} />
+                  ) : (
+                    headerName
+                  )}
+                </Table.HeaderCell>
+              ))}
+            </Table.Row>
+          </Table.Header>
+        )}
         <Table.Body>
           {loading
             ? null

--- a/src/containers/List/ListWrapper.tsx
+++ b/src/containers/List/ListWrapper.tsx
@@ -16,6 +16,7 @@ import PaginationBar from '../../components/List/Pagination'
 import ListFilters from './ListFilters/ListFilters'
 import { useGetFilterDefinitions } from '../../utils/helpers/list/useGetFilterDefinitions'
 import useDebounce from '../../formElementPlugins/search/src/useDebounce'
+import { TableMobileHeader } from '../../utils/tables/TableMobileHeader'
 
 const ListWrapper: React.FC = () => {
   const { t } = useLanguageProvider()
@@ -94,18 +95,21 @@ const ListWrapper: React.FC = () => {
 
   const handleSort = (sortName: string) => {
     const { sortColumn, sortDirection } = sortQuery
-    switch (true) {
-      case sortName === sortColumn && sortDirection === 'descending':
-        setSortQuery({ sortColumn: sortName, sortDirection: 'ascending' })
-        break
-      case sortName === sortColumn && sortDirection === 'ascending':
-        setSortQuery({})
-        break
-      default:
-        // Clicked on a new column
-        setSortQuery({ sortColumn: sortName, sortDirection: 'descending' })
-        break
+
+    if (sortColumn === '') {
+      console.log('Column not sortable')
+      return
     }
+
+    if (sortName === sortColumn) {
+      setSortQuery({
+        sortColumn,
+        sortDirection: sortDirection === 'ascending' ? 'descending' : 'ascending',
+      })
+      return
+    }
+
+    setSortQuery({ sortColumn: sortName })
   }
 
   const visibleFilters = Object.fromEntries(
@@ -136,11 +140,26 @@ const ListWrapper: React.FC = () => {
           </Button>
         ) : null}
       </div>
-      <ListFilters
-        filterDefinitions={visibleFilters}
-        filterListParameters={{ userId: currentUser?.userId || 0, templateCode: type }}
-        totalCount={applicationCount}
-      />
+      <div className="flex-column" style={{ gap: 5 }}>
+        <ListFilters
+          filterDefinitions={visibleFilters}
+          filterListParameters={{ userId: currentUser?.userId || 0, templateCode: type }}
+          totalCount={applicationCount}
+        />
+        <TableMobileHeader
+          options={columns
+            .filter((col) => col.sortName !== '')
+            .map((col) => ({
+              key: col.sortName,
+              text: col.headerName || col.sortName,
+              value: col.sortName,
+            }))}
+          sortColumn={sortQuery.sortColumn}
+          sortDirection={sortQuery.sortDirection}
+          handleSort={handleSort}
+          defaultSort="last-active-date"
+        />
+      </div>
       {columns && (
         <ApplicationsList
           columns={columns}

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -175,6 +175,8 @@ export default {
   FILTER_START_TYPING: 'Start typing...',
   FILTER_SEARCH_LIST: 'Search list...',
   FILTER_SORT_BY: 'Sort by',
+  FILTER_ASCENDING: 'Ascending',
+  FILTER_DESCENDING: 'Descending',
   FILTER_RESET_SORT: 'Reset column sort',
   FILTER_RESET_PAGINATION: 'Reset pagination',
   FILTER_NAMED_DATE_TODAY: 'Today',

--- a/src/utils/helpers/list/mapColumnsByRole.ts
+++ b/src/utils/helpers/list/mapColumnsByRole.ts
@@ -100,14 +100,14 @@ export const useMapColumnsByRole = () => {
     },
     REVIEWER_ACTION: {
       headerName: t('COLUMN_REVIEWER_ACTION'),
-      sortName: 'outcome',
+      sortName: '',
       ColumnComponent: ReviewerActionCell,
       hideMobileLabel: true,
       hideOnMobileTest: (application) => !application.reviewerAction,
     },
     APPLICANT_ACTION: {
       headerName: t('COLUMN_APPLICANT_ACTION'),
-      sortName: 'outcome',
+      sortName: '',
       ColumnComponent: ApplicantActionCell,
       hideMobileLabel: true,
       hideOnMobileTest: (application) =>

--- a/src/utils/tables/TableMobileHeader.tsx
+++ b/src/utils/tables/TableMobileHeader.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { Dropdown, Checkbox } from 'semantic-ui-react'
+import { useLanguageProvider } from '../../contexts/Localisation'
+
+/**
+ * When displayed on mobile devices, the table becomes "stacked", and the header
+ * row ends up in a single cell at the top. It's mostly useless, except for the
+ * ability to change the sort column, so this component provides an alternative
+ * "sort" UI for mobile, and we hide the normal table header
+ */
+
+interface MobileHeaderProps {
+  options: { key: string; text: string; value: string }[]
+  sortColumn?: string
+  sortDirection?: 'ascending' | 'descending'
+  handleSort: Function
+  defaultSort?: string
+}
+
+export const TableMobileHeader: React.FC<MobileHeaderProps> = ({
+  options,
+  sortColumn,
+  sortDirection,
+  handleSort,
+  defaultSort,
+}) => {
+  const { t } = useLanguageProvider()
+
+  return (
+    <div
+      className="flex-row-start-center slightly-smaller-text"
+      style={{ gap: 10, flexWrap: 'wrap' }}
+    >
+      {t('FILTER_SORT_BY')}:
+      <Dropdown
+        selection
+        options={options}
+        value={sortColumn ?? defaultSort}
+        onChange={(_, { value }) => handleSort(value)}
+        style={{ maxHeight: 600 }}
+      />
+      {(sortColumn || defaultSort) && (
+        <Checkbox
+          style={{ fontSize: '95%' }}
+          label={sortDirection === 'ascending' ? t('FILTER_ASCENDING') : t('FILTER_DESCENDING')}
+          checked={sortDirection === 'ascending'}
+          toggle
+          onChange={() => handleSort(sortColumn ?? defaultSort)}
+        />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Fix #1570 

Removes the useless mobile header row and replaces it with a custom component to control sorting.

Changes from this:
![Screenshot 2023-11-01 at 2 30 27 PM](https://github.com/openmsupply/conforma-web-app/assets/5456533/b9a8a36b-488d-478b-b26d-129407c888f2)

to this:
![Screenshot 2023-11-01 at 2 30 53 PM](https://github.com/openmsupply/conforma-web-app/assets/5456533/10b80b4d-f2d4-4bbb-8909-42b13d78919e)

Not sure about the best way to display the ascending/descending state, suggestions welcome.

Currently implemented for Application list and Data view tables.