### PR TITLE
1574 table mobile styles

### DIFF
--- a/semantic/src/site/collections/table.overrides
+++ b/semantic/src/site/collections/table.overrides
@@ -1,10 +1,29 @@
 /*******************************
-         Site Overrides
+         General Site Overrides
 *******************************/
 
 .flex-column {
   display: flex;
   flex-direction: column;
+}
+
+#list-container,
+#linked-applications-container {
+  .ui.table {
+    border-collapse: separate;
+    border-spacing: 0 10px;
+    background: none;
+    border: none;
+  }
+
+  .ui.table td {
+    background: @surfacesWhite;
+    padding: 5px;
+  }
+
+  .ui.table tr {
+    border: none;
+  }
 }
 
 // ********** desktop overrides *******************
@@ -18,20 +37,9 @@
   }
 
   #list-container,
-  #linked-applications-container {
-    .ui.table {
-      border-collapse: separate;
-      border-spacing: 0 10px;
-      background: none;
-      border: none;
-    }
-    .ui.table td {
-      background: @surfacesWhite;
-      padding: 5px;
-    }
+  #linked-applications-container {    
 
     .ui.table tr {
-      border: none;
       height: 52px;
     }
 
@@ -155,5 +163,26 @@
 
 // ********** mobile and small tablet overrides *******************
 
-@media only screen and (max-width: calc(@largestMobileScreen - 1)) {
+@media only screen and (max-width: @largestMobileScreen) {
+  
+  #list-container,
+  #linked-applications-container {
+    .ui.table:not(.unstackable) tr {
+      box-shadow: 0px 0px 0px !important;
+    }    
+
+    .ui.table tr td:first-child {
+      border-top-left-radius: 10px;
+      border-top-right-radius: 10px;
+    }
+
+    .ui.table tr td:last-child {      
+      border-bottom-left-radius: 10px;
+      border-bottom-right-radius: 10px;
+    }
+
+    .ui.table tr {
+      background: none !important;
+    }
+  }
 }

--- a/semantic/src/site/collections/table.overrides
+++ b/semantic/src/site/collections/table.overrides
@@ -184,5 +184,9 @@
     .ui.table tr {
       background: none !important;
     }
+
+    .ui.table td p {
+      word-wrap: anywhere;
+    }
   }
 }

--- a/semantic/src/site/collections/table.overrides
+++ b/semantic/src/site/collections/table.overrides
@@ -169,6 +169,8 @@
   #linked-applications-container {
     .ui.table:not(.unstackable) tr {
       box-shadow: 0px 0px 0px !important;
+      padding-top: .5em;
+      padding-bottom: .5em
     }    
 
     .ui.table tr td:first-child {


### PR DESCRIPTION
- Removed borders
- Less spacing between rows
- Long words will wrap and not break viewport
- Could possibly reduce even more gap between rows... matter of taste really.

Didn't reduce padding inside of rows.  I noticed the padding looks bigger on some applications than others.  I think it has to do with empty row data.
![image](https://github.com/openmsupply/conforma-web-app/assets/17306152/d7dd6790-1363-4517-a6dd-94434a89b95c)

wrapping fix:
![image](https://github.com/openmsupply/conforma-web-app/assets/17306152/01db5943-4960-4dca-9418-273aff2e25e9)
