### PR TITLE
#1574(2) Table mobile extra

### DIFF
--- a/src/components/List/ApplicationsList.tsx
+++ b/src/components/List/ApplicationsList.tsx
@@ -82,6 +82,7 @@ interface ApplicationRowProps {
 
 const ApplicationRow: React.FC<ApplicationRowProps> = ({ refetch, columns, application }) => {
   const { t } = useLanguageProvider()
+  const { isMobile } = useViewport()
   const [deleteApplication, { loading, error }] = useDeleteApplicationMutation({
     variables: { id: application.id || 0 },
     onCompleted: () => refetch(),
@@ -98,14 +99,10 @@ const ApplicationRow: React.FC<ApplicationRowProps> = ({ refetch, columns, appli
     <Table.Row key={`ApplicationList-application-${application.id}`} className="list-row">
       {columns.map(({ ColumnComponent, headerName, hideMobileLabel, hideOnMobileTest }, index) => {
         const rowData = application as Record<string, any>
+        if (isMobile && hideOnMobileTest && hideOnMobileTest(rowData)) return null
         return (
           <Table.Cell key={`ApplicationList-row-${application.id}-${index}`}>
-            <TableCellMobileLabelWrapper
-              label={headerName}
-              rowData={rowData}
-              hideLabel={hideMobileLabel}
-              hideCell={hideOnMobileTest}
-            >
+            <TableCellMobileLabelWrapper label={headerName} hideLabel={hideMobileLabel}>
               <ColumnComponent {...props} />
             </TableCellMobileLabelWrapper>
           </Table.Cell>

--- a/src/containers/DataDisplay/DataViewTable.tsx
+++ b/src/containers/DataDisplay/DataViewTable.tsx
@@ -208,20 +208,20 @@ const DataViewTableContent: React.FC<DataViewTableContentProps> = ({
               className="clickable"
               onClick={() => showDetailsForRow(id)}
             >
-              {rowValues.map((value: any, index: number) => (
-                <Table.Cell key={`value_${index}`}>
-                  <TableCellMobileLabelWrapper
-                    label={headerRow[index].title}
-                    // These values are not currently dynamic, hence no rowData
-                    // sent
-                    hideLabel={headerRow[index].formatting?.hideLabelOnMobile}
-                    hideCell={headerRow[index].formatting?.hideCellOnMobile}
-                    rowData={{}}
-                  >
-                    {getCellComponent(value, headerRow[index], id)}
-                  </TableCellMobileLabelWrapper>
-                </Table.Cell>
-              ))}
+              {rowValues.map((value: any, index: number) => {
+                const { hideLabelOnMobile, hideCellOnMobile } = headerRow[index].formatting
+                if (isMobile && hideCellOnMobile) return null
+                return (
+                  <Table.Cell key={`value_${index}`}>
+                    <TableCellMobileLabelWrapper
+                      label={headerRow[index].title}
+                      hideLabel={hideLabelOnMobile}
+                    >
+                      {getCellComponent(value, headerRow[index], id)}
+                    </TableCellMobileLabelWrapper>
+                  </Table.Cell>
+                )
+              })}
             </Table.Row>
           ))}
         </Table.Body>

--- a/src/utils/tables/TableCellMobileLabelWrapper.tsx
+++ b/src/utils/tables/TableCellMobileLabelWrapper.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { useViewport } from '../../contexts/ViewportState'
-import { HideOnMobileTestMethod } from '../types'
 
 /**
  * When displayed on mobile devices, table rows become "stacked", in that each
@@ -16,22 +15,15 @@ import { HideOnMobileTestMethod } from '../types'
 
 interface MobileLabelWrapperProps {
   label: string
-  rowData: Record<string, unknown>
   hideLabel?: boolean
-  hideCell?: boolean | HideOnMobileTestMethod
 }
 
 export const TableCellMobileLabelWrapper: React.FC<MobileLabelWrapperProps> = ({
   children,
-  rowData,
   label,
-  hideCell,
   hideLabel = false,
 }) => {
   const { isMobile } = useViewport()
-
-  if (isMobile && ((typeof hideCell === 'function' && hideCell(rowData)) || hideCell === true))
-    return null
 
   if (!isMobile || hideLabel) return <>{children}</>
 


### PR DESCRIPTION
This is little something I didn't quite get right yesterday. When a table cell needs to be hidden, we need to hide the whole cell, but the mobile component I made was *inside* the cell, so the cell itself was still there.

So it meant we got an empty "row", but it still took up height, e.g.
<img width="798" alt="Screenshot 2023-11-02 at 9 01 23 PM" src="https://github.com/openmsupply/conforma-web-app/assets/5456533/d1d36221-d2aa-4054-af93-d00e193085da">

So I've removed the "hide" check from the Mobile wrapper component and just done it separately outside the cell. Not quite as "nice", but works as expected:

<img width="367" alt="Screenshot 2023-11-02 at 9 00 12 PM" src="https://github.com/openmsupply/conforma-web-app/assets/5456533/de48decf-fc2d-48c1-ad70-75f9be5bc3cf">


