### PR TITLE
#1586 Header tweaks

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -2654,6 +2654,9 @@ h6:first-child {
       font-size: 100%;
       letter-spacing: unset;
       line-height: 1.3em;
+      #org-label {
+        max-width: 700px;
+      }
     }
     #org-selector .image {
       margin-right: 10px;

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -2644,15 +2644,19 @@ h6:first-child {
 
   #user-area {
     height: @mobileHeaderHeight;
+    padding-left: 10px;
   }
 
   #user-area-left {
     max-width: 100%;
-    padding-right: 20px;
+    padding-right: 25px;
     #org-selector {
-      font-size: 85%;
+      font-size: 100%;
       letter-spacing: unset;
-      line-height: 1.2em;
+      line-height: 1.3em;
+    }
+    #org-selector .image {
+      margin-right: 10px;
     }
   }
 

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -330,6 +330,7 @@ a:hover {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  justify-content: flex-end;
 }
 
 // Menu bar links
@@ -347,6 +348,8 @@ a:hover {
 
 #user-menu {
   text-align: right;
+  display: flex;
+  align-items: center;
   .button {
     margin-top: 10px;
     border-radius: 20px;
@@ -2609,6 +2612,8 @@ h6:first-child {
   }
   #menu-bar {
     font-size: inherit;
+    position: absolute;
+    top: 5px;
     .list {
       display: flex;
       align-items: start;

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -325,6 +325,9 @@ a:hover {
     padding-top: 8px;
     padding-bottom: 8px;
   }
+  @media only screen and (max-width: 860px) {
+    display: none;
+  }
 }
 
 #user-area-left {
@@ -347,11 +350,31 @@ a:hover {
 }
 
 #user-menu {
-  width: clamp(150px, 20%, 300px);
   text-align: right;
+  .button {
+    margin-top: 10px;
+    border-radius: 20px;
+    background-color: @surfacesWhite;
+    color: @darkGrey;
+    min-width: 120px;
+    max-width: 300px;
+  }
+  .ui .dropdown {
+    display: flex;
+  }
+  .ui.dropdown > .text {
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    white-space: nowrap;
+  }
+  .ui.dropdown .menu {
+    right: 0;
+    left: unset;
+  }
 }
 
-// Not currently used, but should be appplied to the Link in the menu
+// Not currently used, but should be applied to the Link in the menu
 // bar that reflects the current page
 .selected-link {
   font-weight: bold;
@@ -378,14 +401,6 @@ a:hover {
   margin-right: 20px;
   height: 100%;
   max-width: 300px;
-}
-
-#user-menu .button {
-  margin-top: 10px;
-  border-radius: 20px;
-  background-color: @surfacesWhite;
-  color: @darkGrey;
-  min-width: 120px;
 }
 
 #language-modal {

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -307,10 +307,6 @@ a:hover {
   min-width: @minimumContainerWidth;
 }
 
-#user-area.ui.container {
-  padding-right: 60px;
-}
-
 #brand-area {
   min-width: 100px;
   max-width: 200px;
@@ -2616,7 +2612,7 @@ h6:first-child {
     .list {
       display: flex;
       align-items: start;
-      gap: 10px;
+      gap: 20px;
     }
     .ui .dropdown {
       display: flex;
@@ -2643,6 +2639,16 @@ h6:first-child {
 
   #user-area {
     height: @mobileHeaderHeight;
+  }
+
+  #user-area-left {
+    max-width: 100%;
+    padding-right: 20px;
+    #org-selector {
+      font-size: 85%;
+      letter-spacing: unset;
+      line-height: 1.2em;
+    }
   }
 
   #menu-bar {

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -2660,6 +2660,8 @@ h6:first-child {
     }
     #org-selector .image {
       margin-right: 10px;
+      max-width: 100px;
+      height: auto;
     }
   }
 

--- a/semantic/src/site/globals/site.variables
+++ b/semantic/src/site/globals/site.variables
@@ -165,7 +165,7 @@
 -------------------------*/
 
 @headerHeight: 100px;
-@mobileHeaderHeight: 80px;
+@mobileHeaderHeight: 60px;
 @footerHeight: 75px;
 @borderRadius: 8px;
 

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -490,7 +490,6 @@ const UserMenu: React.FC<{ user: User; templates: TemplateInList[] }> = ({ user,
           <Button>
             <Button.Content visible>
               <Dropdown
-                // text={`${selectedLanguage?.flag} ${user?.firstName || ''} ${user?.lastName || ''}`}
                 text={
                   (
                     <div

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -417,7 +417,7 @@ const OrgSelector: React.FC<{ user: User; orgs: OrganisationSimple[]; onLogin: F
       {user?.organisation?.logoUrl && (
         <Image src={getFullUrl(user?.organisation?.logoUrl, getServerUrl('public'))} />
       )}
-      <div>
+      <div id="org-label">
         {dropdownOptions.length === 1 ? (
           user?.organisation?.orgName || t('LABEL_NO_ORG')
         ) : (

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -490,7 +490,21 @@ const UserMenu: React.FC<{ user: User; templates: TemplateInList[] }> = ({ user,
           <Button>
             <Button.Content visible>
               <Dropdown
-                text={`${selectedLanguage?.flag} ${user?.firstName || ''} ${user?.lastName || ''}`}
+                // text={`${selectedLanguage?.flag} ${user?.firstName || ''} ${user?.lastName || ''}`}
+                text={
+                  (
+                    <div
+                      style={{ overflow: 'hidden', textOverflow: 'ellipsis', lineHeight: '1.2em' }}
+                    >
+                      <span style={{ fontSize: '150%', marginRight: 5 }}>
+                        {selectedLanguage?.flag}
+                      </span>
+                      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{`${
+                        user?.firstName || ''
+                      } ${user?.lastName || ''}`}</span>
+                    </div>
+                  ) as any
+                }
               >
                 {CommonMenu}
               </Dropdown>


### PR DESCRIPTION
Partly addresses #1586, but doesn't deal with the org dropdown.

Basically, makes things flow better around each other for both mobile and desktop at a wider range of viewport sizes:

### Desktop
- UserMenu button shouldn't wrap, and will expand to fit the name (up to a limit)
- Menu bar shouldn't force org name out of the header (used "position:absolute" for it)
- "Brand Area" logo disappears earlier as the viewport shrinkg

### Mobile
- Header bar size reduced (from 80px to 60)
- Org name fits better into space, and font-size reduced
- Make some margins/padding smaller